### PR TITLE
ci: Groups in packit are prefixed with `@`

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -29,6 +29,6 @@ jobs:
 
     - <<: *copr
       trigger: commit
-      owner: "openscanhub"
+      owner: "@openscanhub"
       project: "devel"
       branch: main


### PR DESCRIPTION
Related: https://gitlab.cee.redhat.com/covscan/covscan/-/issues/84