### PR TITLE
ci: lint workflow should execute on `pull_request`

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,5 +1,9 @@
 name: Lint
-on: [push]
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
... and `push` events on the `main` branch.

Related: https://gitlab.cee.redhat.com/covscan/covscan/-/issues/84