### PR TITLE
client: fix downloading of results for non-RPM tasks

### DIFF
--- a/osh/client/commands/cmd_diff_build.py
+++ b/osh/client/commands/cmd_diff_build.py
@@ -184,7 +184,7 @@ is not even one in your user configuration file \
 
             # store results if user requested this
             if self.results_store_file is not None:
-                fetch_results(self.results_store_file, task_url, self.srpm)
+                fetch_results(self.hub, self.results_store_file, task_id)
 
     def submit_task(self, config, comment, options):
         try:


### PR DESCRIPTION
Since 1fce0c12ad4ab5fafef7a503c462b479f1d2cc60, all tasks submitted through the client have a `result_filename` argument that defines the filename without extensions of the tarball with scan results.  So we should use if it is available.  Otherwise, fall back on the previous implementation.

Related: 1fce0c12ad4ab5fafef7a503c462b479f1d2cc60 ("support scanning of tarballs")