### PR TITLE
ci: Use older version of Ubuntu to run podman compose

### DIFF
--- a/.github/workflows/django-unit-tests.yml
+++ b/.github/workflows/django-unit-tests.yml
@@ -6,7 +6,7 @@ on:
     branches: [main]
 jobs:
   django-unit-tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     # container: fedora:37
     steps:
       - name: Install packages required for unit tests

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -6,7 +6,7 @@ on:
     branches: [main]
 jobs:
   integration-tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Install packages required to run job in a container
         run: |


### PR DESCRIPTION
An update in the podman package in latest Ubuntu has caused broken network functionality, which is causing failures in the CI.

These changes are a workaround for this bug and should be reverted when this bug has been fixed.

Related: https://bugs.launchpad.net/ubuntu/+source/libpod/+bug/2024394