### PR TITLE
Enable Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly


### PR DESCRIPTION
Dependabot is a GitHub dependency manager that automatically updates project dependencies. This commit adds configuration for updating GitHub Actions.

follow-up to discussion in #25