### PR TITLE
client + hub: mark module metadata builds as not eligible for scanning 

### DIFF
--- a/osh/client/commands/shortcuts.py
+++ b/osh/client/commands/shortcuts.py
@@ -33,8 +33,15 @@ def verify_build_exists(nvr, profile):
     except koji.GenericError:
         return False
 
-    return build is not None and \
-        build.get('state') == koji.BUILD_STATES['COMPLETE']
+    if build is None:
+        return False
+
+    # module metadata builds are not supported
+    if build['extra'] is not None and 'typeinfo' in build['extra'] and \
+            'module' in build['extra']['typeinfo']:
+        return False
+
+    return build.get('state') == koji.BUILD_STATES['COMPLETE']
 
 
 def verify_koji_build(build, profiles):
@@ -64,8 +71,8 @@ def verify_koji_build(build, profiles):
     if any(verify_build_exists(build, p) for p in koji_profiles):
         return None
 
-    return f"Build {build} does not exist in {koji_profiles}, has its files \
-deleted, or did not finish successfully."
+    return f"Build {build} does not exist in {koji_profiles}, is a module " +\
+        "metadata build, has its files deleted, or did not finish successfully."
 
 
 def verify_mock(mock, hub):

--- a/osh/client/commands/shortcuts.py
+++ b/osh/client/commands/shortcuts.py
@@ -29,12 +29,12 @@ def verify_build_exists(nvr, profile):
     proxy_object = koji.ClientSession(cfg['server'])
     try:
         # getBuild XML-RPC call is defined here: ./hub/kojihub.py:3206
-        returned_build = proxy_object.getBuild(nvr)
+        build = proxy_object.getBuild(nvr)
     except koji.GenericError:
         return False
 
-    return returned_build is not None and \
-        returned_build.get('state', None) == koji.BUILD_STATES['COMPLETE']
+    return build is not None and \
+        build.get('state', None) == koji.BUILD_STATES['COMPLETE']
 
 
 def verify_koji_build(build, profiles):

--- a/osh/client/commands/shortcuts.py
+++ b/osh/client/commands/shortcuts.py
@@ -34,7 +34,7 @@ def verify_build_exists(nvr, profile):
         return False
 
     return build is not None and \
-        build.get('state', None) == koji.BUILD_STATES['COMPLETE']
+        build.get('state') == koji.BUILD_STATES['COMPLETE']
 
 
 def verify_koji_build(build, profiles):

--- a/osh/client/commands/shortcuts.py
+++ b/osh/client/commands/shortcuts.py
@@ -16,7 +16,7 @@ def check_analyzers(proxy, analyzers_list):
         raise RuntimeError(result)
 
 
-def verify_build_exists(build, profile):
+def verify_build_exists(nvr, profile):
     """
     Verify if build exists
     """
@@ -29,7 +29,7 @@ def verify_build_exists(build, profile):
     proxy_object = koji.ClientSession(cfg['server'])
     try:
         # getBuild XML-RPC call is defined here: ./hub/kojihub.py:3206
-        returned_build = proxy_object.getBuild(build)
+        returned_build = proxy_object.getBuild(nvr)
     except koji.GenericError:
         return False
 

--- a/osh/hub/errata/check.py
+++ b/osh/hub/errata/check.py
@@ -52,8 +52,15 @@ def check_build(nvr, check_additional=False):
             logger.debug('koji: %s', e)
             continue
         build = koji.ClientSession(server).getBuild(nvr)
-        if build:
-            return {'nvr': nvr, 'koji_profile': config}
+        if build is None:
+            continue
+
+        if build['extra'] is not None and 'typeinfo' in build['extra'] and \
+                'module' in build['extra']['typeinfo']:
+            raise PackageBlockedException(
+                'Module metadata builds are not eligible for scanning.')
+
+        return {'nvr': nvr, 'koji_profile': config}
 
     raise RuntimeError(f"Build '{nvr}' does not exist")
 

--- a/osh/hub/errata/check.py
+++ b/osh/hub/errata/check.py
@@ -29,10 +29,8 @@ def check_nvr(nvr):
 
 
 def check_package_is_blocked(package, release):
-    is_blocked = package.is_blocked(release)
-    if is_blocked:
-        raise PackageBlockedException('Package %s is blocked.' %
-                                      (package.name))
+    if package.is_blocked(release):
+        raise PackageBlockedException(f'Package {package.name} is blocked.')
 
 
 def check_obsolete_scan(package, release):


### PR DESCRIPTION
Such builds do not contain any source RPM packages, e.g. https://koji.fedoraproject.org/koji/buildinfo?buildID=2097678.