### PR TITLE
packaging: use a PEP 440 compliant version string

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -61,10 +61,9 @@ for folder in (
 
 if os.path.isdir(".git"):
     if not git_check_tag_for_HEAD(THIS_FILE_PATH):
-        package_version.append("git")
         git_version = get_git_version(THIS_FILE_PATH)
         git_date, git_time = get_git_date_and_time(THIS_FILE_PATH)
-        package_version += [git_date, git_time, git_version]
+        package_version += ['dev' + git_date, git_time, git_version]
 
 setup(
     name="osh",


### PR DESCRIPTION
Without this change, `setuptools` issues the following deprecation warning:

```
/tmp/build-env-ep_0a0rc/lib/python3.11/site-packages/setuptools/dist.py:510: SetuptoolsDeprecationWarning: Invalid version: '0.9.3.git.20230710.144836.0797932'.
!!

        ********************************************************************************
        The version specified is not a valid version according to PEP 440.
        This may not work as expected with newer versions of
        setuptools, pip, and PyPI.

        By 2023-Sep-26, you need to update your project and remove deprecated calls
        or your builds will no longer be supported.

        See https://peps.python.org/pep-0440/ for details.
        ********************************************************************************

!!
```

The downside is that the `*.dev*` builds are seen as downgrade to the previous `*.git*` builds but this problem will disappear as soon as we tag a new release.

Fixes: https://github.com/openscanhub/openscanhub/issues/45