### PR TITLE
hub: add a fixture for the `fedora-37-aarch64` mock config

### DIFF
--- a/osh/hub/scan/fixtures/initial_data.json
+++ b/osh/hub/scan/fixtures/initial_data.json
@@ -1175,6 +1175,14 @@
   }
 },
 {
+  "pk": 172,
+  "model": "scan.mockconfig",
+  "fields": {
+    "enabled": true,
+    "name": "fedora-37-aarch64"
+  }
+},
+{
   "pk": 1,
   "model": "scan.profile",
   "fields": {


### PR DESCRIPTION
So that users can use the default configuration also on aarch64 machines.

Related: https://github.com/openscanhub/openscanhub/pull/29/files#r1255756164