### PR TITLE
ci: enable scanning with Coverity

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -1,0 +1,25 @@
+---
+name: Coverity
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  coverity:
+    if: github.repository == 'openscanhub/openscanhub'
+    name: Coverity Scan
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Coverity scan
+        uses: vapier/coverity-scan-action@v1
+        with:
+          build_language: other  # other is for Python, etc...
+          email: ${{ secrets.COVERITY_SCAN_EMAIL }}
+          token: ${{ secrets.COVERITY_SCAN_TOKEN }}
+          project: openscanhub/openscanhub
+          command: --no-command --fs-capture-search ./osh


### PR DESCRIPTION
At the moment, it is only possible to scan the `main` branch.  This PR is exceptionally done from the repository itself to test that all other Coverity related settings are configured correctly.

Resolves: https://github.com/openscanhub/openscanhub/issues/32