### PR TITLE
hub: remove dead JavaScript code

### DIFF
--- a/osh/hub/templates/waiving/result.html
+++ b/osh/hub/templates/waiving/result.html
@@ -416,24 +416,6 @@ window.onload=function() {
           .forEach(c => c.classList.remove("level_2_show"));
     e.classList.toggle("currently_hiding");
   });
-
-{% comment %}
-  // get tab container
-  var container = document.getElementById("tabContainer");
-    // set current tab
-    var navitem = container.querySelector(".tabs ul li");
-    //store which tab we are on
-    var ident = navitem.id.split("_")[1];
-    navitem.parentNode.setAttribute("data-current",ident);
-    //set current tab with class of activetabheader
-    navitem.setAttribute("class","tabActiveHeader");
-
-    //hide two tab contents we don't need
-    var pages = container.querySelectorAll(".tabpage");
-    for (var i = 1; i < pages.length; i++) {
-      pages[i].style.display="none";
-    }
-{% endcomment %}
 }
 </script>
 {% endblock %}


### PR DESCRIPTION
This code has been commented out since it was introduced in 26d5d46. Moreover, the usage of Django's comment tags is not compatible with Coverity's JavaScript parser.

Fixes: 26d5d46a69a87e3188ce79af8b1ef9411a559dd0 ("UI revamp -- tabs addition, new group")
Resolves: https://github.com/openscanhub/openscanhub/issues/32