### PR TITLE
ci: Disable patch check in codecov

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,6 @@
 # When modifying this file, please validate using
 # curl -X POST --data-binary @codecov.yml https://codecov.io/validate
 comment: false
+coverage:
+  status:
+    patch: off


### PR DESCRIPTION
CI should not fail if a line changed through a patch is not covered by tests.