### PR TITLE
containers: add support for Docker on Linux and Podman on macOS

### DIFF
--- a/.github/workflows/django-unit-tests.yml
+++ b/.github/workflows/django-unit-tests.yml
@@ -23,7 +23,7 @@ jobs:
           # git config --global --add safe.directory /__w/openscanhub/openscanhub
           git clone https://github.com/release-engineering/kobo.git
           containers/scripts/init-db.sh --force --minimal
-          podman exec -it db psql -c 'ALTER USER openscanhub CREATEDB;'
+          podman exec -it db psql -h localhost -U openscanhub -c 'ALTER USER openscanhub CREATEDB;'
           podman exec -it osh-hub /usr/bin/coverage-3.6 run --omit="*site-packages*,*kobo*," osh/hub/manage.py test -v 3 || exit 1
           # Generate xml report to be uploaded to codecov
           podman exec -it osh-hub /usr/bin/coverage-3.6 xml

--- a/compose.yaml
+++ b/compose.yaml
@@ -2,13 +2,13 @@ version: '3.8'
 
 services:
   db:
-    image: quay.io/sclorg/postgresql-12-c8s
+    image: docker.io/postgres:12
     container_name: db
     hostname: db
     environment:
-      POSTGRESQL_PASSWORD: velryba
-      POSTGRESQL_USER: openscanhub
-      POSTGRESQL_DATABASE: openscanhub
+      POSTGRES_PASSWORD: velryba
+      POSTGRES_USER: openscanhub
+      POSTGRES_DB: openscanhub
     ports:
       - "5432:5432"
     networks:

--- a/containers/scripts/deploy.sh
+++ b/containers/scripts/deploy.sh
@@ -89,7 +89,7 @@ clean() {
     # shellcheck disable=2086
     podman-compose -p osh $PROFILE down -v
 
-    images=$(podman images -q 'osh-*' | paste -s -d' ')
+    images=$(podman images -q 'osh-*' | paste -s -d' ' -)
     # podman images -q has a defined format
     # shellcheck disable=2086
     [ -z "$images" ] || podman rmi -f $images

--- a/containers/scripts/deploy.sh
+++ b/containers/scripts/deploy.sh
@@ -13,14 +13,10 @@ CONTAINERS=(
     osh-worker
 )
 
-if [ "$IS_LINUX" = 1 ]; then
-    LABEL='io.podman'
-    PROFILE=
-else
-    LABEL='com.docker'
+if [ "$IS_LINUX" = 0 ]; then
     PROFILE='--profile=full-dev'
 fi
-LABEL+='.compose.project=osh'
+LABEL='com.docker.compose.project=osh'
 START='-d'
 CLEAN='false'
 FORCE='false'

--- a/containers/scripts/deploy.sh
+++ b/containers/scripts/deploy.sh
@@ -89,6 +89,8 @@ test_deploy_env() {
 
 
 clean() {
+    # The $PROFILE variable may be unset.
+    # shellcheck disable=2086
     podman-compose -p osh $PROFILE down -v
 
     images=$(podman images -q 'osh-*' | paste -s -d' ')

--- a/containers/scripts/deploy.sh
+++ b/containers/scripts/deploy.sh
@@ -62,6 +62,12 @@ test_build_env() (
 
     # test if *-compose is installed
     command -v podman-compose
+
+    if [[ -n "$IS_PODMAN" ]] && [[ "$OSTYPE" = *darwin* ]] && grep ':z$' compose.yaml; then
+        echo "podman on macOS does not support SELinux labeling at the moment."
+        echo "Please, remove them from compose.yaml and execute this script again."
+        exit 1
+    fi
 )
 
 

--- a/containers/scripts/deploy.sh
+++ b/containers/scripts/deploy.sh
@@ -13,7 +13,7 @@ CONTAINERS=(
     osh-worker
 )
 
-if [ "$IS_LINUX" = 0 ]; then
+if [ -z "$IS_PODMAN" ]; then
     PROFILE='--profile=full-dev'
 fi
 LABEL='com.docker.compose.project=osh'

--- a/containers/scripts/generate_integration_test_coverage.sh
+++ b/containers/scripts/generate_integration_test_coverage.sh
@@ -32,7 +32,7 @@ main() {
 
     # Remove stale coverage data
     rm -rf htmlcov .coverage
-    podman exec -it db psql -c 'ALTER USER openscanhub CREATEDB;'
+    podman exec -it db psql -h localhost -U openscanhub -c 'ALTER USER openscanhub CREATEDB;'
 
     set -o pipefail
     # Only generate test coverage report for OpenScanHub project
@@ -85,7 +85,7 @@ main() {
     curl http://localhost:8000/task/5/ | grep -Pzo "<th>Priority</th>\n    <td>20</td>"
 
     # insert priority offset setting into the database
-    podman exec -it db psql -d openscanhub -c "INSERT INTO scan_package (name, blocked, priority_offset) VALUES ('expat', false, 1);"
+    podman exec -it db psql -h localhost -U openscanhub -d openscanhub -c "INSERT INTO scan_package (name, blocked, priority_offset) VALUES ('expat', false, 1);"
 
     # submit errata scan and check its tasks priorities
     podman exec osh-client "${CLI_XML[@]}" --hub http://osh-hub:8000/xmlrpc/kerbauth/ --username=user --password=xxxxxx create-scan -b expat-2.5.0-1.fc37 -t expat-2.5.0-2.fc38 --et-scan-id=1 --release=Fedora-37 --owner=admin --advisory-id=1

--- a/containers/scripts/init-db.sh
+++ b/containers/scripts/init-db.sh
@@ -75,8 +75,8 @@ restore() {
     curl -O "https://${FQDN}/${FILENAME}"
 
     podman stop osh-hub
-    podman exec db dropdb openscanhub
-    podman exec db createdb openscanhub
+    podman exec db dropdb -h localhost -U openscanhub openscanhub
+    podman exec db createdb -h localhost -U openscanhub openscanhub
     gzip -cd "$FILENAME" | podman exec -i db psql -h localhost -U openscanhub
     podman start osh-hub
     wait_for_container 'HUB'


### PR DESCRIPTION
See the commit messages for details.

Test cases:
* `containers/scripts/deploy.sh`
* `containers/scripts/deploy.sh --clean`
* `containers/scripts/init-db.sh --force --restore`
* `containers/scripts/init-db.sh --force --minimal`

Workers do not work properly in `podman` on macOS for now.  However, that was already the case for rootless `podman` containers on my Arch machine so I would not classify that as a regression.

edit: add `--minimal` test case