### PR TITLE
containers: get rid of user creation through shell

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -79,6 +79,7 @@ Now, you can start the hub with: `podman start -a osh-hub`. The hub will try to 
 
 #### OSH hub users
 
+* See [initial user fixtures readme](../osh/hub/other/test_fixtures/README.md) for pre-populated users in the minimal database.
 * Enter the interactive shell inside the running container: `podman exec -it osh-hub python3 osh/hub/manage.py shell`
 * Create user and admin:
 

--- a/osh/hub/other/test_fixtures/README.md
+++ b/osh/hub/other/test_fixtures/README.md
@@ -1,0 +1,23 @@
+## Fixtures howto
+
+The fixtures in this directory need to be loaded manually in case needed.
+
+- `users.json`
+
+    - Fixture generation
+
+        The `users.json` fixture is generated via:
+        ```
+        podman exec osh-hub python3 osh/hub/manage.py dumpdata --indent 2 kobo_auth.User > osh/hub/other/test_fixtures/users.json
+        ```
+
+    - Initial users
+
+        The `users.json` fixture consists of following users:
+
+        username | password | is_superuser |
+        ---------|----------|--------------|
+        admin    | xxxxxx   | True
+        user     | xxxxxx   | False
+
+        The initial fixture was based on the original account setup in `init-db.sh`. If you need to customize, either open a django shell or update from the admin panel. If you want your local changes to be persisted, feel free to update the fixtures directly.

--- a/osh/hub/other/test_fixtures/users.json
+++ b/osh/hub/other/test_fixtures/users.json
@@ -1,0 +1,38 @@
+[
+  {
+    "model": "kobo_auth.user",
+    "pk": 1,
+    "fields": {
+      "password": "pbkdf2_sha256$260000$Y1AhkH2Wye8AtwGVo4DkVh$siXy50B5w/8qJcKgquDm6ncKp0+S1pnX9Fy71Cog6oQ=",
+      "last_login": "2023-07-28T10:14:10.268",
+      "is_superuser": true,
+      "username": "admin",
+      "first_name": "",
+      "last_name": "",
+      "email": "admin@example.com",
+      "is_staff": true,
+      "is_active": true,
+      "date_joined": "2023-07-28T10:13:53.861",
+      "groups": [],
+      "user_permissions": []
+    }
+  },
+  {
+    "model": "kobo_auth.user",
+    "pk": 2,
+    "fields": {
+      "password": "pbkdf2_sha256$260000$LAZkXxPRSa8MEZYRxPBsMp$qUgdfDKMVr+f6caMPfwULHgfQM0Iqfh2SwbSRWv6l+k=",
+      "last_login": null,
+      "is_superuser": false,
+      "username": "user",
+      "first_name": "",
+      "last_name": "",
+      "email": "user@example.com",
+      "is_staff": false,
+      "is_active": true,
+      "date_joined": "2023-07-28T10:13:54.036",
+      "groups": [],
+      "user_permissions": []
+    }
+  }
+]


### PR DESCRIPTION
Note the similar user creation hack is also in `setup_db.sh`, with slight different password setup. Since it's used in ci, I didn't update there in this PR.