### PR TITLE
client: add failure handling to `fetch_results`

### DIFF
--- a/osh/client/commands/cmd_diff_build.py
+++ b/osh/client/commands/cmd_diff_build.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the OpenScanHub project.
 
 import os
+import sys
 from xmlrpc.client import Fault
 
 from kobo.shortcuts import random_string
@@ -186,8 +187,9 @@ is not even one in your user configuration file \
             TaskWatcher.watch_tasks(self.hub, [task_id])
 
             # store results if user requested this
-            if self.results_store_file is not None:
-                fetch_results(self.hub, self.results_store_file, task_id)
+            if self.results_store_file is not None and \
+                    not fetch_results(self.hub, self.results_store_file, task_id):
+                sys.exit(1)
 
     def submit_task(self, config, comment, options):
         try:

--- a/osh/client/commands/cmd_download_results.py
+++ b/osh/client/commands/cmd_download_results.py
@@ -40,15 +40,14 @@ class Download_Results(osh.client.OshCommand):
         # login to the hub
         self.connect_to_hub(kwargs)
 
-        failed = False
-
+        success = True
         for task_id in tasks:
             if not self.hub.scan.get_task_info(task_id):
                 print(f"Task {task_id} does not exist!", file=sys.stderr)
-                failed = True
+                success = False
                 continue
 
             fetch_results(self.hub, results_dir, task_id)
 
-        if failed:
+        if not success:
             sys.exit(1)

--- a/osh/client/commands/cmd_download_results.py
+++ b/osh/client/commands/cmd_download_results.py
@@ -47,7 +47,7 @@ class Download_Results(osh.client.OshCommand):
                 success = False
                 continue
 
-            fetch_results(self.hub, results_dir, task_id)
+            success &= fetch_results(self.hub, results_dir, task_id)
 
         if not success:
             sys.exit(1)

--- a/osh/client/commands/shortcuts.py
+++ b/osh/client/commands/shortcuts.py
@@ -4,6 +4,7 @@
 import os
 import re
 import sys
+from urllib.error import HTTPError
 from urllib.request import urlretrieve
 from xmlrpc.client import Fault
 
@@ -134,8 +135,15 @@ def fetch_results(hub, dest, task_id):
     # task_url is url to task with trailing '/'
     url = f"{task_url}log/{tarball}?format=raw"
 
-    print(f"Downloading {tarball}", file=sys.stderr)
-    urlretrieve(url, local_path)
+    print(f"Downloading {tarball}: ", file=sys.stderr, end="")
+    try:
+        urlretrieve(url, local_path)
+    except HTTPError as e:
+        print(e, file=sys.stderr)
+        return False
+
+    print("OK", file=sys.stderr)
+    return True
 
 
 def upload_file(hub, srpm, target_dir, parser):


### PR DESCRIPTION
Fixes the following Traceback for tasks without any results:
```python
$ osh/client/osh-cli download-results 1
Downloading dotnet3.1-3.1.424-1.fc35.tar.xz
Traceback (most recent call last):
  File "/Users/lzaoral/redhat/OpenScanHub/osh/client/osh-cli", line 79, in <module>
    main()
  File "/Users/lzaoral/redhat/OpenScanHub/osh/client/osh-cli", line 72, in main
    parser.run()
  File "/Users/lzaoral/redhat/OpenScanHub/kobo/kobo/cli.py", line 296, in run
    cmd.run(*cmd_args, **cmd_kwargs)
  File "/Users/lzaoral/redhat/OpenScanHub/osh/client/commands/cmd_download_results.py", line 51, in run
    fetch_results(self.hub, results_dir, task_id)
  File "/Users/lzaoral/redhat/OpenScanHub/osh/client/commands/shortcuts.py", line 138, in fetch_results
    urlretrieve(url, local_path)
  File "/opt/homebrew/Cellar/python@3.11/3.11.4_1/Frameworks/Python.framework/Versions/3.11/lib/python3.11/urllib/request.py", line 241, in urlretrieve
    with contextlib.closing(urlopen(url, data)) as fp:
                            ^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.11/3.11.4_1/Frameworks/Python.framework/Versions/3.11/lib/python3.11/urllib/request.py", line 216, in urlopen
    return opener.open(url, data, timeout)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.11/3.11.4_1/Frameworks/Python.framework/Versions/3.11/lib/python3.11/urllib/request.py", line 525, in open
    response = meth(req, response)
               ^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.11/3.11.4_1/Frameworks/Python.framework/Versions/3.11/lib/python3.11/urllib/request.py", line 634, in http_response
    response = self.parent.error(
               ^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.11/3.11.4_1/Frameworks/Python.framework/Versions/3.11/lib/python3.11/urllib/request.py", line 563, in error
    return self._call_chain(*args)
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.11/3.11.4_1/Frameworks/Python.framework/Versions/3.11/lib/python3.11/urllib/request.py", line 496, in _call_chain
    result = func(*args)
             ^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.11/3.11.4_1/Frameworks/Python.framework/Versions/3.11/lib/python3.11/urllib/request.py", line 643, in http_error_default
    raise HTTPError(req.full_url, code, msg, hdrs, fp)
urllib.error.HTTPError: HTTP Error 404: Not Found
```

Related: https://github.com/release-engineering/kobo/pull/214
Related: https://gitlab.cee.redhat.com/covscan/covscan/-/issues/273