### PR TITLE
client: remove compatibility BASH completions

### DIFF
--- a/osh/client/completion/osh-cli.bash
+++ b/osh/client/completion/osh-cli.bash
@@ -234,5 +234,3 @@ _osh_cli()
 }
 
 complete -F _osh_cli osh-cli
-# This is kept here for backward compatibility reasons
-complete -F _osh_cli covscan


### PR DESCRIPTION
... for the old client binary name.

Resolves: https://gitlab.cee.redhat.com/covscan/covscan/-/issues/195