### PR TITLE
hub: Move footer to a separate template

### DIFF
--- a/osh/hub/templates/base.html
+++ b/osh/hub/templates/base.html
@@ -18,7 +18,7 @@ OpenScanHub
 {% endblock %}
 
 {% block footer %}
-Bugs and RFEs should be reported in <a href="https://gitlab.cee.redhat.com/covscan/covscan/issues">GitLab</a>.
+{% include "footer.html" %}
 {% endblock %}
 
 {% block js %}

--- a/osh/hub/templates/footer.html
+++ b/osh/hub/templates/footer.html
@@ -1,0 +1,1 @@
+Bugs and RFEs should be reported on <a href="https://github.com/openscanhub/openscanhub/issues">GitHub</a>.


### PR DESCRIPTION
... to make it easy to override.

Resolves: https://gitlab.cee.redhat.com/covscan/covscan/-/issues/174