### PR TITLE
hub: disable UMB messaging for development instances

### DIFF
--- a/osh/hub/scan/fixtures/initial_data.json
+++ b/osh/hub/scan/fixtures/initial_data.json
@@ -74,7 +74,7 @@
   "pk": 2,
   "model": "scan.appsettings",
   "fields": {
-    "value": "Y",
+    "value": "N",
     "key": "SEND_BUS_MESSAGE"
   }
 },


### PR DESCRIPTION
Resolves: https://github.com/openscanhub/openscanhub/issues/28