### PR TITLE
hub: properly sanitize input urls

### DIFF
--- a/osh/hub/stats/urls.py
+++ b/osh/hub/stats/urls.py
@@ -14,7 +14,7 @@ urlpatterns = [
          name="stats/detail"),
 
     path("release/<int:release_id>/",
-         views.release_list,
+         views.release_stats_list,
          name="stats/release/list"),
     path("release/<int:release_id>/<int:stat_id>/",
          views.release_stats_detail,

--- a/osh/hub/stats/views.py
+++ b/osh/hub/stats/views.py
@@ -5,7 +5,7 @@ import json
 from collections import OrderedDict
 
 from django.http import HttpResponse
-from django.shortcuts import render
+from django.shortcuts import get_object_or_404, render
 from django.urls import reverse
 
 from osh.hub.scan.models import SystemRelease
@@ -14,7 +14,7 @@ from osh.hub.stats.service import display_values
 
 
 def release_list(request, release_id):
-    release = SystemRelease.objects.get(id=release_id)
+    release = get_object_or_404(SystemRelease, id=release_id)
 
     context = {
         'release': release,
@@ -43,8 +43,8 @@ def stats_list(request):
 
 
 def release_stats_detail(request, release_id, stat_id):
-    release = SystemRelease.objects.get(id=release_id)
-    stat_type = StatType.objects.get(id=stat_id)
+    release = get_object_or_404(SystemRelease, id=release_id)
+    stat_type = get_object_or_404(StatType, id=stat_id)
 
     context = {
         'json_url': reverse('stats/release/detail/graph', args=[stat_id, release_id]),
@@ -56,7 +56,7 @@ def release_stats_detail(request, release_id, stat_id):
 
 
 def stats_detail(request, stat_id):
-    stat_type = StatType.objects.get(id=stat_id)
+    stat_type = get_object_or_404(StatType, id=stat_id)
     context = {
         'json_url': reverse('stats/detail/graph', args=[stat_id]),
         'results': display_values(stat_type),
@@ -69,15 +69,15 @@ def stats_detail_graph(request, stat_id, release_id=None):
     """
     Provide data for graph.
     """
+    st = get_object_or_404(StatType, id=stat_id)
+
     if release_id is not None:
-        release = SystemRelease.objects.get(id=release_id)
+        release = get_object_or_404(SystemRelease, id=release_id)
         label = release.tag
-        sr = StatResults.objects.filter(stat=stat_id, release=release)
+        sr = StatResults.objects.filter(stat=st, release=release)
     else:
         label = 'Global'
-        sr = StatResults.objects.filter(stat=stat_id)
-
-    st = StatType.objects.get(id=stat_id)
+        sr = StatResults.objects.filter(stat=st)
 
     data = {
         'title': st.short_comment,

--- a/osh/hub/stats/views.py
+++ b/osh/hub/stats/views.py
@@ -13,7 +13,7 @@ from osh.hub.stats.models import StatResults, StatType
 from osh.hub.stats.service import display_values
 
 
-def release_list(request, release_id):
+def release_stats_list(request, release_id):
     release = get_object_or_404(SystemRelease, id=release_id)
 
     context = {

--- a/osh/hub/waiving/views.py
+++ b/osh/hub/waiving/views.py
@@ -280,6 +280,9 @@ class ResultsListView(ListView):
                 order_prefix = '-'
                 order_by = order_by[1:]
 
+            if order_by not in order_by_mapping:
+                raise Http404('Unknown column to order by: ' + order_by)
+
             order = order_prefix + order_by_mapping[order_by]
         else:
             # order by scan__date, because result might not exist

--- a/osh/hub/waiving/views.py
+++ b/osh/hub/waiving/views.py
@@ -540,7 +540,7 @@ def fixed_defects(request, sb_id, result_group_id):
     sb = get_object_or_404(ScanBinding, id=sb_id)
     context = get_result_context(request, sb)
 
-    context['active_group'] = ResultGroup.objects.get(id=result_group_id)
+    context['active_group'] = get_object_or_404(ResultGroup, id=result_group_id)
     context['defects'] = Defect.objects.filter(result_group=result_group_id,
                                                state=DEFECT_STATES['FIXED']).order_by("order")
     context['display_form'] = False


### PR DESCRIPTION
Resolves: https://issues.redhat.com/browse/OSH-175

Do not forget to execute `osh-stats` and submit at least one ET task before testing!

Test cases (without changes traceback, after changes 404):
* http://0.0.0.0:8000/stats/123456789
* http://0.0.0.0:8000/stats/release/123456789
* http://0.0.0.0:8000/stats/release/54/123456789
* http://0.0.0.0:8000/stats/123456789/graph
* http://0.0.0.0:8000/stats/54/123456789/graph
* http://0.0.0.0:8000/waiving/?order_by=foo
* http://0.0.0.0:8000/waiving/1/123456789/fixed

`123456789` can be replaced by any other unknown ID.

edit: typo