### PR TITLE
containers: Cleaning container images should be optional

### DIFF
--- a/containers/scripts/deploy.sh
+++ b/containers/scripts/deploy.sh
@@ -80,7 +80,10 @@ prepare_deploy() {
         return 4
     fi
 
-    clean
+    # Bring compose down
+    # The $PROFILE variable may be unset.
+    # shellcheck disable=2086
+    podman-compose -p osh $PROFILE down -v
 }
 
 


### PR DESCRIPTION
`prepare_deploy` function should not clean images from previous builds. Users should explicitly specify `--clean` option if they want to clear image cache from previous builds.