### PR TITLE
containers: speed-up container build

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ report bugs and feature requests on GitHub using the above URL.
 
 ### hub:
 - `csdiff`
-- `file`
 - `gzip`
 - `httpd`
 - `koji`
@@ -33,6 +32,7 @@ report bugs and feature requests on GitHub using the above URL.
 
 ### worker:
 - `csmock`
+- `file`
 - `koji`
 - `python3-kobo-client`
 - `python3-kobo-rpmlib`

--- a/containers/client.Dockerfile
+++ b/containers/client.Dockerfile
@@ -7,8 +7,6 @@ WORKDIR /src
 ENV PYTHONPATH=.:kobo
 ENV OSH_CLIENT_CONFIG_FILE=osh/client/client-local.conf
 
-RUN echo -e "max_parallel_downloads=20\nfastestmirror=True" >> /etc/dnf/dnf.conf
-
 RUN dnf -y --setopt=tsflags=nodocs install \
     koji \
     gzip \

--- a/containers/client.Dockerfile
+++ b/containers/client.Dockerfile
@@ -1,11 +1,11 @@
 FROM quay.io/centos/centos:stream8
 
-RUN dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
+RUN dnf install -y dnf-plugins-core https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
+RUN dnf config-manager --set-enabled powertools
 
 WORKDIR /src
 
 ENV PYTHONPATH=.:kobo
-ENV OSH_CLIENT_CONFIG_FILE=osh/client/client-local.conf
 
 RUN dnf -y --setopt=tsflags=nodocs install \
     koji \
@@ -15,6 +15,9 @@ RUN dnf -y --setopt=tsflags=nodocs install \
 # store coverage to a separate volume
 RUN printf '[run]\ndata_file = /cov/coverage\n' > /coveragerc
 
+### END OF COMMON PART
+
+ENV OSH_CLIENT_CONFIG_FILE=osh/client/client-local.conf
 RUN touch /CLIENT_IS_READY
 
 CMD sleep inf

--- a/containers/client.Dockerfile
+++ b/containers/client.Dockerfile
@@ -9,11 +9,8 @@ ENV OSH_CLIENT_CONFIG_FILE=osh/client/client-local.conf
 
 RUN dnf -y --setopt=tsflags=nodocs install \
     koji \
-    gzip \
     python3-coverage \
-    python3-koji \
-    python36 \
-    xz
+    python36
 
 # store coverage to a separate volume
 RUN printf '[run]\ndata_file = /cov/coverage\n' > /coveragerc

--- a/containers/client.Dockerfile
+++ b/containers/client.Dockerfile
@@ -10,7 +10,7 @@ ENV OSH_CLIENT_CONFIG_FILE=osh/client/client-local.conf
 RUN dnf -y --setopt=tsflags=nodocs install \
     koji \
     python3-coverage \
-    python36
+    python3
 
 # store coverage to a separate volume
 RUN printf '[run]\ndata_file = /cov/coverage\n' > /coveragerc

--- a/containers/client.Dockerfile
+++ b/containers/client.Dockerfile
@@ -10,7 +10,6 @@ ENV OSH_CLIENT_CONFIG_FILE=osh/client/client-local.conf
 RUN echo -e "max_parallel_downloads=20\nfastestmirror=True" >> /etc/dnf/dnf.conf
 
 RUN dnf -y --setopt=tsflags=nodocs install \
-    file \
     koji \
     gzip \
     python3-coverage \

--- a/containers/hub/Dockerfile
+++ b/containers/hub/Dockerfile
@@ -13,26 +13,18 @@ ENV PYTHONPATH=.:kobo
 RUN rm /etc/rpm/macros.image-language-conf
 
 RUN dnf -y --setopt=tsflags=nodocs install \
-    /usr/bin/krb5-config \
-    cpio \
     csdiff \
-    csmock \
-    gcc \
-    glibc-langpack-en \
     gzip \
     koji \
     python3-bugzilla \
     python3-coverage \
     python3-csdiff \
-    python3-devel \
     python3-django3 \
     python3-gssapi \
     python3-jira \
-    python3-koji \
     python3-psycopg2 \
     python3-qpid-proton \
     python36 \
-    postgresql{,-libs} \
     xz
 
 # store coverage to a separate volume

--- a/containers/hub/Dockerfile
+++ b/containers/hub/Dockerfile
@@ -9,8 +9,6 @@ WORKDIR /src
 
 ENV PYTHONPATH=.:kobo
 
-RUN echo -e "max_parallel_downloads=20\nfastestmirror=True" >> /etc/dnf/dnf.conf
-
 # enable installation of gettext message objects
 RUN rm /etc/rpm/macros.image-language-conf
 

--- a/containers/hub/Dockerfile
+++ b/containers/hub/Dockerfile
@@ -24,7 +24,7 @@ RUN dnf -y --setopt=tsflags=nodocs install \
     python3-jira \
     python3-psycopg2 \
     python3-qpid-proton \
-    python36 \
+    python3 \
     xz
 
 # store coverage to a separate volume

--- a/containers/hub/Dockerfile
+++ b/containers/hub/Dockerfile
@@ -1,7 +1,5 @@
 FROM quay.io/centos/centos:stream8
 
-EXPOSE 8000
-
 RUN dnf install -y dnf-plugins-core https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
 RUN dnf config-manager --set-enabled powertools
 
@@ -9,26 +7,32 @@ WORKDIR /src
 
 ENV PYTHONPATH=.:kobo
 
+RUN dnf -y --setopt=tsflags=nodocs install \
+    koji \
+    python3-coverage \
+    python3
+
+# store coverage to a separate volume
+RUN printf '[run]\ndata_file = /cov/coverage\n' > /coveragerc
+
+### END OF COMMON PART
+
 # enable installation of gettext message objects
 RUN rm /etc/rpm/macros.image-language-conf
 
 RUN dnf -y --setopt=tsflags=nodocs install \
     csdiff \
     gzip \
-    koji \
     python3-bugzilla \
-    python3-coverage \
     python3-csdiff \
     python3-django3 \
     python3-gssapi \
     python3-jira \
     python3-psycopg2 \
     python3-qpid-proton \
-    python3 \
     xz
 
-# store coverage to a separate volume
-RUN printf '[run]\ndata_file = /cov/coverage\n' > /coveragerc
+EXPOSE 8000
 
 RUN adduser --system --no-create-home osh
 

--- a/containers/scripts/generate_integration_test_coverage.sh
+++ b/containers/scripts/generate_integration_test_coverage.sh
@@ -11,7 +11,7 @@ CLI_COV=(
     env
     OSH_CLIENT_CONFIG_FILE=osh/client/client-local.conf
     PYTHONPATH=.:kobo
-    /usr/bin/coverage-3.6 run --parallel-mode '--omit=*site-packages*,*kobo*,' --rcfile=/coveragerc
+    /usr/bin/coverage-3 run --parallel-mode '--omit=*site-packages*,*kobo*,' --rcfile=/coveragerc
     osh/client/osh-cli
 )
 
@@ -19,7 +19,7 @@ CLI_XML=(
     env
     OSH_CLIENT_CONFIG_FILE=osh/client/client-local.conf
     PYTHONPATH=.:kobo
-    /usr/bin/coverage-3.6 run --parallel-mode '--omit=*site-packages*,*kobo*,' --rcfile=/coveragerc
+    /usr/bin/coverage-3 run --parallel-mode '--omit=*site-packages*,*kobo*,' --rcfile=/coveragerc
     osh/hub/scripts/osh-xmlrpc-client.py
 )
 
@@ -130,7 +130,7 @@ main() {
     podman exec osh-client "${CLI_XML[@]}" --hub http://osh-hub:8000/xmlrpc/kerbauth/ --username=user --password=xxxxxx create-scan -b units-2.18-3.fc30 -t units-2.22-5.fc39 --et-scan-id=1 --release=Fedora-37 --owner=admin --advisory-id=1
 
     # test generation of usage statistics
-    podman exec osh-hub /usr/bin/coverage-3.6 run --parallel-mode '--omit=*site-packages*,*kobo*,' --rcfile=/coveragerc osh/hub/scripts/osh-stats
+    podman exec osh-hub /usr/bin/coverage-3 run --parallel-mode '--omit=*site-packages*,*kobo*,' --rcfile=/coveragerc osh/hub/scripts/osh-stats
 
     set +e; set +o pipefail
 
@@ -139,18 +139,18 @@ main() {
     podman exec -i osh-hub scripts/kill_django_server.sh
 
     # Combine coverage report for hub, worker and client
-    podman exec -it osh-client /usr/bin/coverage-3.6 combine --rcfile=/coveragerc
+    podman exec -it osh-client /usr/bin/coverage-3 combine --rcfile=/coveragerc
     podman cp osh-client:/cov/coverage .
 
     # Avoid generating html reports in GitHub Actions CI
     if [[ "$GITHUB_ACTIONS" = "true" ]];
     then
         # We use codecov in GitHub Actions CI. Upload xml reports to it.
-        podman exec -it osh-client /usr/bin/coverage-3.6 xml --rcfile=/coveragerc
+        podman exec -it osh-client /usr/bin/coverage-3 xml --rcfile=/coveragerc
         podman cp osh-client:/cov/coverage.xml .
     else
         # Convert test coverage to html
-        podman exec -it osh-client /usr/bin/coverage-3.6 html --rcfile=/coveragerc -d /cov/htmlcov
+        podman exec -it osh-client /usr/bin/coverage-3 html --rcfile=/coveragerc -d /cov/htmlcov
         podman cp osh-client:/cov/htmlcov .
     fi
 

--- a/containers/worker.Dockerfile
+++ b/containers/worker.Dockerfile
@@ -6,20 +6,24 @@ RUN dnf config-manager --set-enabled powertools
 WORKDIR /src
 
 ENV PYTHONPATH=.:kobo
-ENV OSH_WORKER_CONFIG_FILE=osh/worker/worker-local.conf
 
 RUN dnf -y --setopt=tsflags=nodocs install \
-    csmock \
-    file \
     koji \
     python3-coverage \
     python3
 
-RUN adduser csmock -G mock
-
 # store coverage to a separate volume
 RUN printf '[run]\ndata_file = /cov/coverage\n' > /coveragerc
 
+### END OF COMMON PART
+
+RUN dnf -y --setopt=tsflags=nodocs install \
+    csmock \
+    file
+
+RUN adduser csmock -G mock
+
+ENV OSH_WORKER_CONFIG_FILE=osh/worker/worker-local.conf
 RUN touch /WORKER_IS_READY
 
 CMD coverage-3 run --parallel-mode --omit="*site-packages*,*kobo*," --rcfile=/coveragerc osh/worker/osh-worker -f

--- a/containers/worker.Dockerfile
+++ b/containers/worker.Dockerfile
@@ -8,8 +8,6 @@ WORKDIR /src
 ENV PYTHONPATH=.:kobo
 ENV OSH_WORKER_CONFIG_FILE=osh/worker/worker-local.conf
 
-RUN echo -e "max_parallel_downloads=20\nfastestmirror=True" >> /etc/dnf/dnf.conf
-
 RUN dnf -y --setopt=tsflags=nodocs install \
     cppcheck \
     csmock \

--- a/containers/worker.Dockerfile
+++ b/containers/worker.Dockerfile
@@ -13,7 +13,7 @@ RUN dnf -y --setopt=tsflags=nodocs install \
     file \
     koji \
     python3-coverage \
-    python36
+    python3
 
 RUN adduser csmock -G mock
 

--- a/containers/worker.Dockerfile
+++ b/containers/worker.Dockerfile
@@ -9,16 +9,11 @@ ENV PYTHONPATH=.:kobo
 ENV OSH_WORKER_CONFIG_FILE=osh/worker/worker-local.conf
 
 RUN dnf -y --setopt=tsflags=nodocs install \
-    cppcheck \
     csmock \
-    csmock-plugin-unicontrol \
     file \
-    gzip \
     koji \
     python3-coverage \
-    python3-gssapi \
-    python36 \
-    xz
+    python36
 
 RUN adduser csmock -G mock
 

--- a/osh.spec
+++ b/osh.spec
@@ -57,6 +57,7 @@ OpenScanHub shared files for client, hub and worker.
 %package worker
 Summary: OpenScanHub worker
 Requires: csmock
+Requires: file
 Requires: koji
 Requires: python3-kobo-client
 Requires: python3-kobo-rpmlib
@@ -91,7 +92,6 @@ Requires: koji
 Requires: xz
 
 Requires: csdiff
-Requires: file
 Requires: python3-bugzilla
 Requires: python3-csdiff
 Requires: python3-jira


### PR DESCRIPTION
Minor improvements that should make the container builds a bit faster:
```console 
# Before
$ ./containers/scripts/deploy.sh --clean
$ time ./containers/scripts/deploy.sh --full-dev
...
66.46s user 35.73s system 36% cpu 4:37.33 total

# After
$ ./containers/scripts/deploy.sh --clean
$ time ./containers/scripts/deploy.sh --full-dev
...
67.64s user 36.66s system 41% cpu 4:14.20 total
```