### PR TITLE
containers: add `/usr/bin/pg_isready` to hub container

### DIFF
--- a/containers/hub/Dockerfile
+++ b/containers/hub/Dockerfile
@@ -21,6 +21,7 @@ RUN printf '[run]\ndata_file = /cov/coverage\n' > /coveragerc
 RUN rm /etc/rpm/macros.image-language-conf
 
 RUN dnf -y --setopt=tsflags=nodocs install \
+    /usr/bin/pg_isready \
     csdiff \
     gzip \
     python3-bugzilla \


### PR DESCRIPTION
... which was removed by mistake.

Fixes the following error:
```
/run.sh: line 9: pg_isready: command not found
/run.sh: line 9: pg_isready: command not found
/run.sh: line 9: pg_isready: command not found
...
```

Fortunately, the error is not fatal and the container would still start eventually.

Fixes: e309e3e0f674a9bca127128a1f8ebea3a28bae8d ("containers: do not install redundant packages")