### PR TITLE
hub: fix overlapping pagination controls

### DIFF
--- a/osh/hub/static-assets/css/redhat.css
+++ b/osh/hub/static-assets/css/redhat.css
@@ -782,3 +782,14 @@ div#defects div.events_list div.code {
 }
 
 /**/
+
+/* PAGINATIONS */
+
+/* Override broken style from kobo */
+.paginator {
+    float: unset;
+    margin: -0.75em 0em -1em 0em;
+    text-align: right;
+}
+
+/**/

--- a/osh/hub/templates/scan/package_list.html
+++ b/osh/hub/templates/scan/package_list.html
@@ -4,7 +4,7 @@
 {% block content %}
 <h2>{% trans "Package list" %}</h2>
 
-<form method="GET" target="" style="float: left;">
+<form method="GET" target="">
   {{ form.search }}
   <input type="submit" value="{% trans "Search" %}"/>
   {{ form.blocked }} Show only blocked packages


### PR DESCRIPTION
Kobo's CSS declare the `.paginator` class as `float`.  Therefore, in some cases the pagination controls would overlap with other page content making the visuals look corrupted.

Override the broken style in OSH because changes in kobo's styles may break other projects that depend on them.

Resolves: https://gitlab.cee.redhat.com/osh/covscan/-/issues/227


Testing instructions:
* Create a local OSH instance with the database snapshot restored.
* Check that all views with pagination controls are no longer corrupted with this PR appleid. 