### PR TITLE
create-release.sh: create a release on GitHub

### DIFF
--- a/create-release.sh
+++ b/create-release.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -e
+set -x
+SELF="$0"
+TAG="$1"
+TOKEN="$2"
+
+PROJ="openscanhub/openscanhub"
+
+usage() {
+    printf "Usage: %s TAG TOKEN\n" "$SELF" >&2
+    exit 1
+}
+
+# check arguments
+test "$TAG" = "$(git describe --tags "$TAG")" || usage
+test -n "$TOKEN" || usage
+
+# create a new release on GitHub
+curl "https://api.github.com/repos/${PROJ}/releases" \
+    --fail --verbose \
+    --header "Authorization: token ${TOKEN}" \
+    --data '{
+    "tag_name": "'"${TAG}"'",
+    "target_commitish": "main",
+    "name": "'"${TAG}"'",
+    "draft": false,
+    "prerelease": false
+}'


### PR DESCRIPTION
The script is taken from csutils/csdiff:
https://github.com/csutils/csdiff/blob/csdiff-3.0.4/upload-release.sh

But the script does not upload any files.  It only creates the release on GitHub so that we can use more native download URLs.