### PR TITLE
worker: use the `-t` option for cspodman, too

### DIFF
--- a/osh/worker/csmock_runner.py
+++ b/osh/worker/csmock_runner.py
@@ -123,10 +123,11 @@ class CsmockRunner:
             cmd += " --force-global-cleanup-on-exit"
         else:
             cmd = "csmock"
-            if analyzers:
-                cmd += ' -t ' + shlex.quote(analyzers)
             if profile:
                 cmd += ' -r ' + shlex.quote(profile)
+
+        if analyzers:
+            cmd += ' -t ' + shlex.quote(analyzers)
 
         if output_path:
             cmd += ' -o ' + shlex.quote(output_path)


### PR DESCRIPTION
cspodman recently introduced the `-t` option compatible with csmock. So we can propagate the list of enabled analyzers for both the tools.

Related: https://issues.redhat.com/browse/OSH-313