### PR TITLE
hub: restrict user list/detail page access to staff users only

### DIFF
--- a/osh/hub/settings.py
+++ b/osh/hub/settings.py
@@ -202,6 +202,13 @@ def _get_secret(name):
 BZ_API_KEY = _get_secret('bugzilla_secret')
 JIRA_API_KEY = _get_secret('jira_secret')
 
+# Denote whether the access to user list/detail view is restricted
+# Possible values:
+# "" (empty string) = Anonymous access (default)
+# "authenticated" = Authenticated users
+# "staff" = Staff (admin) users only
+USERS_ACL_PERMISSION = "staff"
+
 # read the real SECRET_KEY from SECRET_KEY_FILE if availble
 try:
     with open(SECRET_KEY_FILE) as f:


### PR DESCRIPTION
Related: https://github.com/release-engineering/kobo/pull/228
Related: https://github.com/release-engineering/kobo/issues/209
Related: https://issues.redhat.com/browse/OSH-78


This PR depends on upstream pull: https://github.com/release-engineering/kobo/pull/228