### PR TITLE
hub: use default styles for the scan submission form

### DIFF
--- a/osh/hub/templates/scan/new.html
+++ b/osh/hub/templates/scan/new.html
@@ -4,9 +4,12 @@
 {% block content %}
 <h2>{% trans title %}</h2>
 
-<form action="{% url 'scan/new' %}" method="post">{% csrf_token %}
-{{ form.as_p }}
-<input type="submit" value="Submit" />
+<form action="{% url 'scan/new' %}" method="post">
+  {% csrf_token %}
+  <table class="details">
+    {{ form.as_table }}
+  </table>
+  <input type="submit" value="Submit" />
 </form>
 
 {% endblock %}


### PR DESCRIPTION
This should make the scan submission form look a bit more professional and finished.