### PR TITLE
worker: create a subtask `ScanBinding` before task assignment

### DIFF
--- a/osh/worker/tasks/task_errata_diff_build.py
+++ b/osh/worker/tasks/task_errata_diff_build.py
@@ -47,10 +47,10 @@ class ErrataDiffBuild(TaskBase):
         # (re)scan base if needed
         base_task_args = self.hub.worker.ensure_base_is_scanned_properly(scan_id, self.task_id)
         if base_task_args is not None:
-            subtask_id = self.spawn_subtask(*base_task_args)
             self.hub.worker.set_scan_to_basescanning(scan_id)
-            self.hub.worker.assign_task(subtask_id)
+            subtask_id = self.spawn_subtask(*base_task_args)
             self.hub.worker.create_sb(subtask_id)
+            self.hub.worker.assign_task(subtask_id)
 
             self.wait()
             self.hub.worker.set_scan_to_scanning(scan_id)


### PR DESCRIPTION
... so that it is still created even when the parent task is killed by an exception.

Related: https://github.com/openscanhub/openscanhub/issues/156