### PR TITLE
worker: always create subtasks on the same worker

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ report bugs and feature requests on GitHub using the above URL.
 - `python3-jira`
 - `python3-kobo-client`
 - `python3-kobo-django`
-- `python3-kobo-hub >= 0.26.0`
+- `python3-kobo-hub >= 0.32.0`
 - `python3-kobo-rpmlib`
 - `python3-mod_wsgi`
 - `python3-psycopg2`
@@ -36,7 +36,7 @@ report bugs and feature requests on GitHub using the above URL.
 - `koji`
 - `python3-kobo-client`
 - `python3-kobo-rpmlib`
-- `python3-kobo-worker >= 0.30.0`
+- `python3-kobo-worker >= 0.32.0`
 
 ### client:
 - `koji`

--- a/osh.spec
+++ b/osh.spec
@@ -63,7 +63,7 @@ Requires: file
 Requires: koji
 Requires: python3-kobo-client
 Requires: python3-kobo-rpmlib
-Requires: python3-kobo-worker >= 0.30.0
+Requires: python3-kobo-worker >= 0.32.0
 Requires: %{name}-common = %{version}-%{release}
 Requires: osh-worker-conf
 
@@ -80,7 +80,7 @@ Requires: mod_ssl
 Requires: python3-django >= %{min_required_version_django}
 Requires: python3-kobo-client
 Requires: python3-kobo-django
-Requires: python3-kobo-hub >= 0.26.0
+Requires: python3-kobo-hub >= 0.32.0
 Requires: python3-kobo-rpmlib
 Requires: python3-mod_wsgi
 # PostgreSQL adapter for python

--- a/osh/worker/tasks/task_build.py
+++ b/osh/worker/tasks/task_build.py
@@ -35,8 +35,7 @@ class Build:
 
         # scan base
         if base_task_args:
-            subtask_id = self.spawn_subtask(*base_task_args)
-            self.hub.worker.assign_task(subtask_id)
+            self.spawn_subtask(*base_task_args, inherit_worker=True)
             self.wait()
 
         if upload_id:

--- a/osh/worker/tasks/task_errata_diff_build.py
+++ b/osh/worker/tasks/task_errata_diff_build.py
@@ -40,17 +40,16 @@ class ErrataDiffBuild(TaskBase):
         # update analyzers version cache if needed
         cache_task_args = self.hub.worker.ensure_cache(mock_config, scanning_session_id)
         if cache_task_args is not None:
-            cache_subtask_id = self.spawn_subtask(*cache_task_args)
-            self.hub.worker.assign_task(cache_subtask_id)
+            self.spawn_subtask(*cache_task_args, inherit_worker=True)
             self.wait()
 
         # (re)scan base if needed
         base_task_args = self.hub.worker.ensure_base_is_scanned_properly(scan_id, self.task_id)
         if base_task_args is not None:
             self.hub.worker.set_scan_to_basescanning(scan_id)
-            subtask_id = self.spawn_subtask(*base_task_args)
+
+            subtask_id = self.spawn_subtask(*base_task_args, inherit_worker=True)
             self.hub.worker.create_sb(subtask_id)
-            self.hub.worker.assign_task(subtask_id)
 
             self.wait()
             self.hub.worker.set_scan_to_scanning(scan_id)


### PR DESCRIPTION
... to fix the following crash due to race between the automated task assignment to workers by the hub and the `hub.worker.assign_task` XML-RPC method.

```python
Traceback (most recent call last):
  File "/usr/lib/python3.9/site-packages/kobo/worker/taskmanager.py", line 423, in run_task
    task.run()
  File "/usr/lib/python3.9/site-packages/osh/worker/tasks/task_errata_diff_build.py", line 52, in run
    self.hub.worker.assign_task(subtask_id)
  File "/usr/lib64/python3.9/xmlrpc/client.py", line 1122, in __call__
    return self.__send(self.__name, args)
  File "/usr/lib64/python3.9/xmlrpc/client.py", line 1464, in __request
    response = self.__transport.request(
  File "/usr/lib/python3.9/site-packages/kobo/xmlrpc.py", line 598, in request
    result = transport_class.request(self, *args, **kwargs)
  File "/usr/lib64/python3.9/xmlrpc/client.py", line 1166, in request
    return self.single_request(host, handler, request_body, verbose)
  File "/usr/lib/python3.9/site-packages/kobo/xmlrpc.py", line 511, in _single_request3
    return self.parse_response(response)
  File "/usr/lib64/python3.9/xmlrpc/client.py", line 1354, in parse_response
    return u.close()
  File "/usr/lib64/python3.9/xmlrpc/client.py", line 668, in close
    raise Fault(**self._stack[0])
xmlrpc.client.Fault: <Fault 1: Traceback (most recent call last):
  File "/usr/lib/python3.6/site-packages/kobo/hub/models.py", line 861, in assign_task
    self.__lock(worker_id, new_state=TASK_STATES["ASSIGNED"], initial_states=(TASK_STATES["FREE"], TASK_STATES["CREATED"]))
  File "/usr/lib/python3.6/site-packages/kobo/hub/models.py", line 836, in __lock
    raise ObjectDoesNotExist()
django.core.exceptions.ObjectDoesNotExist
```

Related:  https://github.com/release-engineering/kobo/pull/230
Resolves: https://github.com/openscanhub/openscanhub/issues/156
Resolves: https://issues.redhat.com/browse/OSH-358