### PR TITLE
hub: return 0 if the sum in `get_scans_new_defects_count` is empty

### DIFF
--- a/osh/hub/waiving/service.py
+++ b/osh/hub/waiving/service.py
@@ -156,11 +156,7 @@ def get_scans_new_defects_count(scan_id):
     """Return number of newly introduced bugs for particular scan"""
     rgs = ResultGroup.objects.filter(result__scanbinding__scan__id=scan_id,
                                      defect_type=DEFECT_STATES['NEW'])
-    try:
-        count = rgs.aggregate(Sum("defects_count"))['defects_count__sum']
-    except KeyError:
-        count = 0
-    return count
+    return rgs.aggregate(sum=Sum("defects_count"))['sum'] or 0
 
 
 def get_waivers_for_rg(rg):


### PR DESCRIPTION
If a `Sum` in a Django query is empty, the final value will be `None` and not `0` as one would expect.  Because the code returns `0` in case of the `KeyError` exception (which, by the way, cannot happen here...), it is safe to assume that the code is meant to return `0` in the case of no newly introduced defects.

When I was at it, I have also refactored the code a bit.

Fixes the following traceback:
```python
Traceback (most recent call last):
  File "/usr/lib/python3.9/site-packages/django/core/handlers/exception.py", line 47, in inner
    response = get_response(request)
  File "/usr/lib/python3.9/site-packages/django/core/handlers/base.py", line 181, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/usr/lib/python3.9/site-packages/django/utils/decorators.py", line 130, in _wrapped_view
    response = view_func(request, *args, **kwargs)
  File "/usr/lib/python3.9/site-packages/django/views/decorators/cache.py", line 44, in _wrapped_view_func
    response = view_func(request, *args, **kwargs)
  File "/usr/lib/python3.9/site-packages/django/contrib/admin/sites.py", line 232, in inner
    return view(request, *args, **kwargs)
  File "/usr/lib/python3.9/site-packages/osh/hub/scan/admin.py", line 63, in notify
    result = send_scan_notification(request, scan_id)
  File "/usr/lib/python3.9/site-packages/osh/hub/scan/notify.py", line 278, in send_scan_notification
    message = mg.generate_regular_scan_text()
  File "/usr/lib/python3.9/site-packages/osh/hub/scan/notify.py", line 215, in generate_regular_scan_text
    return self.generate_general_text() % {
  File "/usr/lib/python3.9/site-packages/osh/hub/scan/notify.py", line 185, in generate_general_text
    "New defects count: %d" % get_scans_new_defects_count(self.scan.id),
```
Fixes: a00701ba6a11606b7955b689273da5edc73e2cc0 ("scan notif rewrite, update texts")\
Resolves: https://github.com/openscanhub/openscanhub/issues/73