### PR TITLE
client: fix downloading of AnalyzerVersionRetriever task results

### DIFF
--- a/osh/client/commands/shortcuts.py
+++ b/osh/client/commands/shortcuts.py
@@ -104,6 +104,7 @@ def _get_result_filename(task_args):
       for an SRPM build or the 'build/nvr' key for Brew builds.
     * ErrataDiffBuild uses the 'build' key and used 'brew_build' key in
       the past.
+    * AnalyzerVersionRetriever always uses 'output' as the filename.
     """
     if 'result_filename' in task_args:
         return task_args['result_filename']
@@ -114,10 +115,14 @@ def _get_result_filename(task_args):
     if "brew_build" in task_args:
         return task_args["brew_build"]
 
-    nvr = task_args['build']
-    if isinstance(nvr, dict):
-        nvr = nvr['nvr']
-    return nvr
+    if 'build' in task_args:
+        nvr = task_args['build']
+        if isinstance(nvr, dict):
+            nvr = nvr['nvr']
+        return nvr
+
+    # default filename for `csmock --no-scan` tasks
+    return 'output'
 
 
 def fetch_results(hub, dest, task_id):

--- a/osh/worker/csmock_runner.py
+++ b/osh/worker/csmock_runner.py
@@ -201,10 +201,7 @@ class CsmockRunner:
         execute csmock command for listing analyzers and versions
         returns path to dir with results
         """
-        if self.tmpdir:
-            output_path = os.path.join(self.tmpdir, 'output.tar.xz')
-        else:
-            output_path = os.path.join(os.getcwd(), 'csmock-output')
+        output_path = os.path.join(self.tmpdir or os.getcwd(), 'output.tar.xz')
 
         if profile == "cspodman":
             cmd = "cspodman"


### PR DESCRIPTION
Fixes the following traceback:
```python
Traceback (most recent call last):
  File "/Users/lzaoral/redhat/OpenScanHub/osh/client/osh-cli", line 79, in <module>
    main()
  File "/Users/lzaoral/redhat/OpenScanHub/osh/client/osh-cli", line 72, in main
    parser.run()
  File "/Users/lzaoral/redhat/OpenScanHub/kobo/kobo/cli.py", line 296, in run
    cmd.run(*cmd_args, **cmd_kwargs)
  File "/Users/lzaoral/redhat/OpenScanHub/osh/client/commands/cmd_download_results.py", line 51, in run
    fetch_results(self.hub, results_dir, task_id)
  File "/Users/lzaoral/redhat/OpenScanHub/osh/client/commands/shortcuts.py", line 128, in fetch_results
    tarball = _get_result_filename(task_info['args']) + '.tar.xz'
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/lzaoral/redhat/OpenScanHub/osh/client/commands/shortcuts.py", line 116, in _get_result_filename
    nvr = task_args['build']
          ~~~~~~~~~^^^^^^^^^
KeyError: 'build'
```

Resolves: https://github.com/openscanhub/openscanhub/issues/88