### PR TITLE
worker: do not write to the log twice

### DIFF
--- a/osh/worker/osh-worker.service
+++ b/osh/worker/osh-worker.service
@@ -9,7 +9,7 @@ ExecStartPre=test -r /etc/osh/worker.conf
 ExecStart=/usr/sbin/osh-worker -f
 KillMode=process
 Restart=on-failure
-StandardOutput=append:/var/log/osh/worker.log
+StandardOutput=null
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
As reported by Lukáš Zaoral, the default installation of OSH worker was writing each log message twice by mistake.  The log `LOG_FILE` field in the `worker.conf` configuration file works as expected in the foreground mode, too.  I must have done something wrong while testing it initially.

Fixes: commit 30fadad7945a4c1de316956a77641b93a99bd649
Closes: https://github.com/openscanhub/openscanhub/pull/173