### PR TITLE
ci: do not scan Coverity by Coverity

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -22,4 +22,4 @@ jobs:
           email: ${{ secrets.COVERITY_SCAN_EMAIL }}
           token: ${{ secrets.COVERITY_SCAN_TOKEN }}
           project: openscanhub/openscanhub
-          command: --no-command --fs-capture-search .
+          command: --no-command --fs-capture-search . --fs-capture-search-exclude-regex '/cov-(int|analysis)/'


### PR DESCRIPTION
Fixes: 60a72f4145769ed066e58dd6f9b312b2a47f72a4 ("ci: scan the whole repository through Coverity")