### PR TITLE
client: add --state option in `osh-cli find-tasks`

### DIFF
--- a/osh/client/commands/cmd_find_tasks.py
+++ b/osh/client/commands/cmd_find_tasks.py
@@ -56,9 +56,18 @@ these options: --regex, --package, --nvr"
             type="string",
             nargs=1,
             help=(f"query by task state. This option is used in conjunction with -r, -p, or -n. "
-                  f"Specify multiple states by using it multiple times, like '-s failed -s closed'. "
-                  f"Valid choices include {', '.join([s.lower() for s in TASK_STATES])}.")
+                  f"Specify multiple states by using it multiple times, like '-s FAILED -s CLOSED'. "
+                  f"Valid choices include {', '.join(TASK_STATES)}.")
         )
+
+    def _validate_states(self, states):
+        """
+        State validator, raise error in case user specifies invalid task states
+        """
+        valid_states = list(TASK_STATES)
+        invalid_states = [s for s in states if s.upper() not in valid_states]
+        if invalid_states:
+            self.parser.error(f"Invalid state(s) specified: {', '.join(invalid_states)}.")
 
     def run(self, *args, **kwargs):
         regex = kwargs.pop("regex")
@@ -85,6 +94,7 @@ these options: --regex, --package, --nvr"
             # nvr is default one, so we don't care if it's specified
             query['nvr'] = query_string
         if states:
+            self._validate_states(states)
             query['states'] = [TASK_STATES[state.upper()] for state in states]
         task_ids = self.hub.scan.find_tasks(query)
 

--- a/osh/client/commands/cmd_find_tasks.py
+++ b/osh/client/commands/cmd_find_tasks.py
@@ -3,6 +3,8 @@
 
 import sys
 
+from kobo.client.constants import TASK_STATES
+
 import osh.client
 
 
@@ -47,10 +49,21 @@ these options: --regex, --package, --nvr"
             action="store_true",
             help="query by NVR (default one)"
         )
+        self.parser.add_option(
+            "-s",
+            "--states",
+            action="append",
+            type="string",
+            nargs=1,
+            help=(f"query by task state. This option is used in conjunction with -r, -p, or -n. "
+                  f"Specify multiple states by using it multiple times, like '-s failed -s closed'. "
+                  f"Valid choices include {', '.join([s.lower() for s in TASK_STATES])}.")
+        )
 
     def run(self, *args, **kwargs):
         regex = kwargs.pop("regex")
         package_name = kwargs.pop("package")
+        states = kwargs.get("states")
 
         latest = kwargs.pop("latest")
 
@@ -71,6 +84,8 @@ these options: --regex, --package, --nvr"
         else:
             # nvr is default one, so we don't care if it's specified
             query['nvr'] = query_string
+        if states:
+            query['states'] = [TASK_STATES[state.upper()] for state in states]
         task_ids = self.hub.scan.find_tasks(query)
 
         if not task_ids:

--- a/osh/client/completion/_osh-cli
+++ b/osh/client/completion/_osh-cli
@@ -76,8 +76,7 @@ _osh-cli_args()
                 '(-r --regex)'{-r,--regex}'[query by regular expression (python, module: re)]'
                 '(-p --pacakge)'{-p,--package}'[query by package name]'
                 '(-n --nvr)'{-n,--nvr}'[query by NVR (default one)]'
-                '(-s --state)'{-s,--state}'[query by task state. This option is used \
-in conjunction with -r, -p, or -n.]'
+                '*'{-s+,--state=}'[query by task state. This option is used in conjunction with -r, -p, or -n.]:osh:->states'
             )
             ;;
 
@@ -171,6 +170,10 @@ in conjunction with -r, -p, or -n.]'
 
         profiles)
             _osh-cli_complete profiles
+            ;;
+
+        states)
+            _osh-cli_complete task-states
             ;;
 
         warn)

--- a/osh/client/completion/_osh-cli
+++ b/osh/client/completion/_osh-cli
@@ -76,6 +76,8 @@ _osh-cli_args()
                 '(-r --regex)'{-r,--regex}'[query by regular expression (python, module: re)]'
                 '(-p --pacakge)'{-p,--package}'[query by package name]'
                 '(-n --nvr)'{-n,--nvr}'[query by NVR (default one)]'
+                '(-s --state)'{-s,--state}'[query by task state. This option is used \
+in conjunction with -r, -p, or -n.]'
             )
             ;;
 

--- a/osh/client/completion/main.py
+++ b/osh/client/completion/main.py
@@ -7,6 +7,7 @@ import pickle
 from datetime import datetime, timedelta
 
 from kobo.client import HubProxy
+from kobo.client.constants import TASK_STATES
 
 from osh.common.conf import get_config_dict
 
@@ -55,6 +56,13 @@ def fetch_mock_configs(hub):
     return [x['name'] for x in hub.mock_config.all() if x['enabled']]
 
 
+def fetch_task_states(hub):
+    """
+    Return all possible task states
+    """
+    return list(TASK_STATES)
+
+
 def load_from_cache(action):
     """
     Try to load up to date data from the cache
@@ -99,7 +107,8 @@ def main(args):
 ACTIONS = {
     'analyzers': fetch_analyzers,
     'mock-configs': fetch_mock_configs,
-    'profiles': fetch_profiles
+    'profiles': fetch_profiles,
+    'task-states': fetch_task_states,
 }
 
 

--- a/osh/client/completion/osh-cli.bash
+++ b/osh/client/completion/osh-cli.bash
@@ -69,6 +69,7 @@ _osh_cli()
         COMPREPLY+=( $(compgen -W '-r --regex  ' -- "${cur}") )
         COMPREPLY+=( $(compgen -W '-p --package' -- "${cur}") )
         COMPREPLY+=( $(compgen -W '-n --nvr    ' -- "${cur}") )
+        COMPREPLY+=( $(compgen -W '-s --state  ' -- "${cur}") )
         ;;
 
     list-tasks)

--- a/osh/client/completion/osh-cli.bash
+++ b/osh/client/completion/osh-cli.bash
@@ -65,11 +65,19 @@ _osh_cli()
         ;;
 
     find-tasks)
-        COMPREPLY+=( $(compgen -W '-l --latest ' -- "${cur}") )
-        COMPREPLY+=( $(compgen -W '-r --regex  ' -- "${cur}") )
-        COMPREPLY+=( $(compgen -W '-p --package' -- "${cur}") )
-        COMPREPLY+=( $(compgen -W '-n --nvr    ' -- "${cur}") )
-        COMPREPLY+=( $(compgen -W '-s --state  ' -- "${cur}") )
+        case "${prev}" in
+        -s|--state)
+            _osh_cli_complete task-states
+            return
+            ;;
+        *)
+            COMPREPLY+=( $(compgen -W '-l --latest ' -- "${cur}") )
+            COMPREPLY+=( $(compgen -W '-r --regex  ' -- "${cur}") )
+            COMPREPLY+=( $(compgen -W '-p --package' -- "${cur}") )
+            COMPREPLY+=( $(compgen -W '-n --nvr    ' -- "${cur}") )
+            COMPREPLY+=( $(compgen -W '-s --state= ' -- "${cur}") )
+            ;;
+        esac
         ;;
 
     list-tasks)

--- a/osh/hub/osh_xmlrpc/scan.py
+++ b/osh/hub/osh_xmlrpc/scan.py
@@ -245,9 +245,10 @@ def find_tasks(request, query):
     """
     if not isinstance(query, dict):
         return []
-    nvr = query.get('nvr', None)
-    package_name = query.get('package_name', None)
-    regex = query.get('regex', None)
+    nvr = query.get('nvr')
+    package_name = query.get('package_name')
+    regex = query.get('regex')
+    states = query.get('states')
 
     result = []
     tasks = None
@@ -257,6 +258,8 @@ def find_tasks(request, query):
         tasks = Task.objects.filter(label__regex=package_name + r"-\d")
     elif regex:
         tasks = Task.objects.filter(label__regex=regex)
+    if states:
+        tasks = tasks.filter(state__in=states)
     if tasks is not None:
         result = list(tasks.order_by("-dt_finished").values_list(
             "id", flat=True))


### PR DESCRIPTION
This PR adds ability in `osh-client find-tasks` to filter tasks by state, used in conjunction with other options. Example:
```
$ osh-cli find-tasks --help
Usage: osh-cli find-tasks [options] <query_string>

Options:
  -h, --help                  show this help message and exit
  --username=USERNAME         specify user
  --password=PASSWORD         specify password
  --hub=HUB                   specify URL of XML-RPC interface on hub
  -l, --latest                display only latest task
  -r, --regex                 query by regular expression (python, module: re)
  -p, --package               query by package name
  -n, --nvr                   query by NVR (default one)
  -s STATES, --states=STATES  query by task state. This option is used in
                              conjunction with -r, -p, or -n. Specify multiple
                              states by using it multiple times, like '-s
                              FAILED -s CLOSED'. Valid choices include FREE,
                              ASSIGNED, OPEN, CLOSED, CANCELED, FAILED,
                              INTERRUPTED, TIMEOUT, CREATED.
$ osh-cli find-tasks -r bash
3
2
1
$ osh-cli find-tasks -r bash -s CLOSED -s failed
3
```

Resolves: https://issues.redhat.com/browse/OSH-376