### PR TITLE
hub: fix the `All defects` links on waiver page

### DIFF
--- a/osh/hub/waiving/views.py
+++ b/osh/hub/waiving/views.py
@@ -193,10 +193,10 @@ def add_logs_to_context(sb):
                                  (FIXED_HTML_FILE, 'HTML'),
                                  (FIXED_DIFF_FILE, 'JSON')], logs_list))
     logs.append(create_log_dict('All defects', 'Document_content_32.png',
-                                log_prefix + '.html',
-                                [(log_prefix + '.err', 'TXT'),
-                                 (log_prefix + '.html', 'HTML'),
-                                 (log_prefix + '.js', 'JSON')], logs_list))
+                                log_prefix + '-all.html',
+                                [(log_prefix + '-all.err', 'TXT'),
+                                 (log_prefix + '-all.html', 'HTML'),
+                                 (log_prefix + '-all.js', 'JSON')], logs_list))
     logs.append(create_log_dict('Scan Log', 'Message_log_32.png',
                                 'stdout.log',
                                 [('stdout.log', 'TXT')], logs_list))


### PR DESCRIPTION
... such that they really point to all defects and not to the compatibility symlinks to important defects only.

This fixes a user experience issue introduced by the following change in csmock:
https://github.com/csutils/csmock/pull/126