### PR TITLE
hub: remove all remaining mentions to `ScanningSession`

### DIFF
--- a/osh/hub/errata/scanner.py
+++ b/osh/hub/errata/scanner.py
@@ -69,8 +69,6 @@ class AbstractScheduler:
         self.task_args['args'] = {}
         self.task_args['args']['build'] = self.nvr
         self.task_args['args']['profile'] = 'errata'
-        # TODO: remove the 'scanning_session' argument when workers are updated
-        self.task_args['args']['scanning_session'] = None
         self.task_args['args']['su_user'] = AppSettings.setting_get_su_user()
         self.scan_args['nvr'] = self.nvr
         self.scan_args['username'] = self.package_owner

--- a/osh/hub/osh_xmlrpc/worker.py
+++ b/osh/hub/osh_xmlrpc/worker.py
@@ -128,8 +128,7 @@ def fail_scan(request, scan_id, reason=None):
 
 @validate_worker
 def get_scanning_args(request, profile):
-    # TODO: remove the `or` expression
-    return Profile.objects.get(name=(profile or 'errata')).command_arguments
+    return Profile.objects.get(name=profile).command_arguments
 
 
 @validate_worker
@@ -157,8 +156,7 @@ def ensure_cache(request, mock_config, profile):
         # FIXME: hard-coded at two places for now
         mock_config = 'rhel-9-alpha-x86_64'
     if not AnalyzerVersion.objects.is_cache_uptodate(mock_config):
-        # TODO: remove the `or` expression
-        profile = Profile.objects.get(name=(profile or 'errata'))
+        profile = Profile.objects.get(name=profile)
         analyzers = profile.analyzers
         csmock_args = profile.csmock_args
         su_user = AppSettings.setting_get_su_user()


### PR DESCRIPTION
Fixes: 460aeea953a1918e55ad2ce4891c573be322297e ("hub: make ErrataDiffBuild task independent of ScanningSession")
Related: https://github.com/openscanhub/openscanhub/pull/170
Related: https://github.com/openscanhub/openscanhub/pull/191