### PR TITLE
draft: worker: set memory to 95% in the osh-worker unit file

### DIFF
--- a/osh/worker/osh-worker.service
+++ b/osh/worker/osh-worker.service
@@ -10,6 +10,8 @@ ExecStart=/usr/sbin/osh-worker -f
 KillMode=process
 Restart=on-failure
 StandardOutput=null
+MemoryHigh=95%
+MemoryMax=95%
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
it is safer if we kill either the wild scan task, or the osh-worker daemon itself, rather than killing core part of the operating system and let the daemon pick other scanning task to fail or misbehave in such a broken environment

Related: https://issues.redhat.com/browse/OSH-394
Closes: https://github.com/openscanhub/openscanhub/pull/193