### PR TITLE
hub: add auth redirect fallback

### DIFF
--- a/osh/hub/settings.py
+++ b/osh/hub/settings.py
@@ -176,6 +176,10 @@ XMLRPC_METHODS = {
 LOGIN_URL_NAME = 'auth/krb5login'
 LOGIN_EXEMPT_URLS = ['.*xmlrpc/.*']
 
+# Default redirect targets for unsafe or invalid ?next URLs
+LOGIN_REDIRECT_URL = 'index'
+LOGOUT_REDIRECT_URL = 'index'
+
 VALID_TASK_LOG_EXTENSIONS = ['.log', '.ini', '.err', '.out', '.js', '.txt']
 
 # override default values with custom ones from local settings


### PR DESCRIPTION
Do not forget to use an unsafe URL, e.g. a hostname not in `setting.ALLOWED_HOSTS` for testing.