### PR TITLE
packaging: install the suitable `postgresql` package directly

### DIFF
--- a/osh.spec
+++ b/osh.spec
@@ -103,7 +103,12 @@ Requires: python3-bugzilla
 Requires: python3-csdiff
 Requires: python3-jira
 
-Requires(post): %{_bindir}/pg_isready
+# Workaround for https://bugzilla.redhat.com/show_bug.cgi?id=2255013
+%if 0%{?fedora} < 40 && 0%{?rhel} < 10
+Requires(post): postgresql < 16
+%else
+Requires(post): postgresql
+%endif
 
 Requires: %{name}-common = %{version}-%{release}
 Recommends: osh-hub-conf


### PR DESCRIPTION
For some reason, intransitive dependency on `/usr/bin/pg_isready` will install the `postgresql16` package which then conflicts with the `postgresql-server` installed by the Testing Farm.

This is a workaround for the following error:
```
+ dnf install -y openssl postgresql-server /usr/sbin/semanage
Last metadata expiration check: 0:00:07 ago on Mon 18 Dec 2023 08:20:03 AM UTC.
Package openssl-1:3.1.1-4.fc39.x86_64 is already installed.
Error:
 Problem: problem with installed package postgresql16-16.1-1.fc39.x86_64
  - package postgresql16-16.1-1.fc39.x86_64 from @System conflicts with postgresql provided by postgresql-15.4-1.fc39.i686 from fedora
  - package postgresql16-16.1-1.fc39.x86_64 from testing-farm-tag-repository conflicts with postgresql provided by postgresql-15.4-1.fc39.i686 from fedora
  - package postgresql16-16.1-1.fc39.x86_64 from updates conflicts with postgresql provided by postgresql-15.4-1.fc39.i686 from fedora
  - package postgresql-server-15.4-1.fc39.i686 from fedora requires postgresql(x86-32) = 15.4-1.fc39, but none of the providers can be installed
  - conflicting requests
  - package postgresql-server-15.4-1.fc39.x86_64 from fedora requires postgresql(x86-64) = 15.4-1.fc39, but none of the providers can be installed
  - package postgresql16-16.1-1.fc39.x86_64 from updates conflicts with postgresql provided by postgresql-15.4-1.fc39.x86_64 from testing-farm-tag-repository
  - package postgresql16-16.1-1.fc39.x86_64 from updates conflicts with postgresql provided by postgresql-15.4-1.fc39.x86_64 from fedora
  - package postgresql16-16.1-1.fc39.x86_64 from testing-farm-tag-repository conflicts with postgresql provided by postgresql-15.4-1.fc39.x86_64 from testing-farm-tag-repository
  - package postgresql16-16.1-1.fc39.x86_64 from testing-farm-tag-repository conflicts with postgresql provided by postgresql-15.4-1.fc39.x86_64 from fedora
  - package postgresql16-16.1-1.fc39.x86_64 from @System conflicts with postgresql provided by postgresql-15.4-1.fc39.x86_64 from testing-farm-tag-repository
  - package postgresql16-16.1-1.fc39.x86_64 from @System conflicts with postgresql provided by postgresql-15.4-1.fc39.x86_64 from fedora
  - package postgresql-server-15.4-1.fc39.x86_64 from testing-farm-tag-repository requires postgresql(x86-64) = 15.4-1.fc39, but none of the providers can be installed
(try to add '--allowerasing' to command line to replace conflicting packages or '--skip-broken' to skip uninstallable packages)
Shared connection to 3.136.87.64 closed.
```