### PR TITLE
packaging: do not restart osh-worker upon update

### DIFF
--- a/osh.spec
+++ b/osh.spec
@@ -220,7 +220,8 @@ fi
 %systemd_preun osh-worker.service
 
 %postun worker
-%systemd_postun_with_restart osh-worker.service
+# osh-worker does not implement reload and restart would interrupt running tasks
+%systemd_postun osh-worker.service
 
 %files worker-conf-devel
 %attr(640,root,root) %config(noreplace) %{_sysconfdir}/osh/worker.conf


### PR DESCRIPTION
osh-worker does not implement `reload` and `restart` would interrupt running tasks.  Until a proper `reload` operation is implemented in the osh-worker daemon, it is better to let administrator restart it manually when they are ready for that (e.g. after setting `max_load` to zero and waiting for the already running tasks to finish).

Resolves: https://issues.redhat.com/browse/OSH-221