### PR TITLE
containers: only set the worker container arch if the fixtures were loaded

### DIFF
--- a/containers/hub/run.sh
+++ b/containers/hub/run.sh
@@ -22,10 +22,10 @@ osh/hub/manage.py migrate
 # hub work.
 if [ "$(osh/hub/manage.py dumpdata scan.MockConfig)" = "[]" ]; then
     osh/hub/manage.py loaddata osh/hub/{scan,waiving}/fixtures/initial_data.json
-fi
 
-# Assign native arch to the worker
-python3 scripts/add-worker-arch.py
+    # Assign native arch to the worker
+    python3 scripts/add-worker-arch.py
+fi
 
 # Run a dummy SMTP server in background
 python3 -m smtpd -n -c DebuggingServer localhost:8025 >> /tmp/emails.log &


### PR DESCRIPTION
This fixes a `osh-hub` container crash when starting with the database snapshot restored.
```
+ python3 scripts/add-worker-arch.py
Traceback (most recent call last):
  File "scripts/add-worker-arch.py", line 28, in <module>
    main()
  File "scripts/add-worker-arch.py", line 19, in main
    worker = Worker.objects.get(name='localhost')
  File "/usr/lib/python3.6/site-packages/django/db/models/manager.py", line 85, in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
  File "/usr/lib/python3.6/site-packages/django/db/models/query.py", line 437, in get
    self.model._meta.object_name
kobo.hub.models.DoesNotExist: Worker matching query does not exist.
```