### PR TITLE
client: fix the `--hub` option

### DIFF
--- a/osh/client/__init__.py
+++ b/osh/client/__init__.py
@@ -16,7 +16,7 @@ class OshCommand(ClientCommand):
 
         # For compatibility with older kobo releases
         sig = inspect.signature(self.set_hub)
-        if len(sig.parameters) == 4:
+        if 'hub' in sig.parameters:
             params.append(hub)
 
         self.set_hub(*params)


### PR DESCRIPTION
Previously, the code in OSH was not properly detecting the required support in `kobo`.

Fixes: 6d3e3cb3d57b0f4ca442ab919d2b6ee097032041 ("client: handle the --hub option globally")