### PR TITLE
packaging: do not trigger `osh-{retention,stats}.service` on each update of the RPM packages

### DIFF
--- a/osh.spec
+++ b/osh.spec
@@ -275,7 +275,7 @@ pg_isready -h localhost && %{python3_sitelib}/osh/hub/manage.py migrate
 %systemd_preun osh-{retention,stats}.{service,timer}
 
 %postun hub
-%systemd_postun_with_restart osh-{retention,stats}.{service,timer}
+%systemd_postun osh-{retention,stats}.{service,timer}
 
 %files hub-conf-devel
 %attr(640,root,apache) %config(noreplace) %{python3_sitelib}/osh/hub/settings_local.py

--- a/osh.spec
+++ b/osh.spec
@@ -269,16 +269,13 @@ fi
 # this only takes an effect if PostgreSQL is running and the database exists
 pg_isready -h localhost && %{python3_sitelib}/osh/hub/manage.py migrate
 
-%systemd_post osh-retention.service osh-retention.timer
-%systemd_post osh-stats.service osh-stats.timer
+%systemd_post osh-{retention,stats}.{service,timer}
 
 %preun hub
-%systemd_preun osh-retention.service osh-retention.timer
-%systemd_preun osh-stats.service osh-stats.timer
+%systemd_preun osh-{retention,stats}.{service,timer}
 
 %postun hub
-%systemd_postun_with_restart osh-retention.service osh-retention.timer
-%systemd_postun_with_restart osh-stats.service osh-stats.timer
+%systemd_postun_with_restart osh-{retention,stats}.{service,timer}
 
 %files hub-conf-devel
 %attr(640,root,apache) %config(noreplace) %{python3_sitelib}/osh/hub/settings_local.py

--- a/osh/hub/osh-retention.service
+++ b/osh/hub/osh-retention.service
@@ -1,11 +1,8 @@
 [Unit]
 Description=OpenScanHub retention policy enforcer
-StartLimitBurst=3
-StartLimitIntervalSec=12h
 
 [Service]
 ExecStart=/usr/sbin/osh-retention
-Restart=on-failure
 Type=oneshot
 
 [Install]

--- a/osh/hub/osh-stats.service
+++ b/osh/hub/osh-stats.service
@@ -1,11 +1,8 @@
 [Unit]
 Description=OpenScanHub statistics collector
-StartLimitBurst=2
-StartLimitIntervalSec=2h
 
 [Service]
 ExecStart=/usr/sbin/osh-stats
-Restart=on-failure
 Type=oneshot
 
 [Install]


### PR DESCRIPTION
They will be triggered by the systemd timer according to the configured schedule.

Also do not restart `osh-{retention,stats}.service` on failure.  These are one-shot services.  If something fails, which should not happen under normal circumstances, they will be started again by the systemd timer later on (daily in the default configuration).

Fixes: https://github.com/openscanhub/openscanhub/issues/235