### PR TITLE
ci: use latest released Fedora in Testing Farm

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -42,7 +42,7 @@ jobs:
       job: tests
       trigger: pull_request
       targets:
-          - fedora-latest-x86_64
+          - fedora-latest-stable-x86_64
           - epel-8-x86_64
           - epel-9-x86_64
 


### PR DESCRIPTION
Otherwise, Packit will schedule tests on branched releases that my be frozen.