### PR TITLE
Add `CODEOWNERS` file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,16 @@
+# CODEOWNERS file defines default GitHub PR reviewers for specified paths
+#
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+# Each line is a file pattern followed by one or more owners.
+
+# Order of the rules is important!  The last matching pattern has the most
+# precedence.
+
+# Default reviewers
+* @kdudka @lzaoral
+
+# Reviewers for specific paths
+.github/     @kdudka @lzaoral @siteshwar
+.packit.yaml @kdudka @lzaoral @siteshwar
+containers/  @kdudka @lzaoral @siteshwar
+tests/       @kdudka @lzaoral @siteshwar


### PR DESCRIPTION
`CODEOWNERS` file defines default GitHub PR reviewers for specified paths.

Resolves: https://github.com/openscanhub/openscanhub/issues/113