### PR TITLE
hub: enable reading of secrets in `settings_local.py`

### DIFF
--- a/osh/hub/other/settings_util.py
+++ b/osh/hub/other/settings_util.py
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-FileCopyrightText: Copyright contributors to the OpenScanHub project.
+
+import os
+
+
+def get_secret(name, directory):
+    try:
+        with open(os.path.join(directory, name)) as f:
+            return f.read().strip()
+    except OSError:
+        return None

--- a/osh/hub/settings.py
+++ b/osh/hub/settings.py
@@ -179,6 +179,13 @@ LOGIN_EXEMPT_URLS = ['.*xmlrpc/.*']
 LOGIN_REDIRECT_URL = 'index'
 LOGOUT_REDIRECT_URL = 'index'
 
+# Denote whether the access to user list/detail view is restricted
+# Possible values:
+# "" (empty string) = Anonymous access (default)
+# "authenticated" = Authenticated users
+# "staff" = Staff (admin) users only
+USERS_ACL_PERMISSION = "staff"
+
 VALID_TASK_LOG_EXTENSIONS = ['.log', '.ini', '.err', '.out', '.js', '.txt']
 
 # override default values with custom ones from local settings
@@ -199,12 +206,6 @@ def _get_secret(name):
 BZ_API_KEY = _get_secret('bugzilla_secret')
 JIRA_API_KEY = _get_secret('jira_secret')
 
-# Denote whether the access to user list/detail view is restricted
-# Possible values:
-# "" (empty string) = Anonymous access (default)
-# "authenticated" = Authenticated users
-# "staff" = Staff (admin) users only
-USERS_ACL_PERMISSION = "staff"
 
 # read the real SECRET_KEY from SECRET_KEY_FILE if availble
 try:

--- a/osh/hub/settings.py
+++ b/osh/hub/settings.py
@@ -16,8 +16,8 @@ PROJECT_DIR = os.path.dirname(__file__)
 
 URL_PREFIX = "/osh"
 
-# file to read the real SECRET_KEY from
-SECRET_KEY_FILE = "/var/lib/osh/hub/secret_key"
+# directory to read the real SECRET_KEY from
+SECRET_KEY_DIR = "/var/lib/osh/hub/"
 
 # where to read API keys from
 SECRETS_DIR = "/etc/osh/hub/secrets"
@@ -81,9 +81,6 @@ TEMPLATES = [
 ROOT_URLCONF = 'osh.hub.urls'
 ROOT_MENUCONF = 'osh.hub.menu'
 
-# dummy secret key
-# (will be overridden by the content of SECRET_KEY_FILE if available)
-SECRET_KEY = 'x' * 50
 
 AUTHENTICATION_BACKENDS = (
     'kobo.django.auth.krb5.Krb5RemoteUserBackend',
@@ -195,22 +192,21 @@ except ImportError:
     pass
 
 
-def _get_secret(name):
+###############################################################################
+# Secrets
+###############################################################################
+
+def _get_secret(name, directory=SECRETS_DIR):
     try:
-        with open(os.path.join(SECRETS_DIR, name)) as f:
+        with open(os.path.join(directory, name)) as f:
             return f.read().strip()
     except OSError:
         return None
 
 
+# Issue trackers
 BZ_API_KEY = _get_secret('bugzilla_secret')
 JIRA_API_KEY = _get_secret('jira_secret')
 
-
-# read the real SECRET_KEY from SECRET_KEY_FILE if availble
-try:
-    with open(SECRET_KEY_FILE) as f:
-        key = f.readline()
-        SECRET_KEY = key.strip()
-except OSError:
-    pass
+# Secret key ((will be overridden by the content of SECRET_KEY_FILE if available)
+SECRET_KEY = _get_secret('secret_key', directory=SECRET_KEY_DIR) or 'x' * 50

--- a/osh/hub/settings.py
+++ b/osh/hub/settings.py
@@ -196,17 +196,11 @@ except ImportError:
 # Secrets
 ###############################################################################
 
-def _get_secret(name, directory=SECRETS_DIR):
-    try:
-        with open(os.path.join(directory, name)) as f:
-            return f.read().strip()
-    except OSError:
-        return None
-
+from osh.hub.other.settings_util import get_secret  # noqa: E402
 
 # Issue trackers
-BZ_API_KEY = _get_secret('bugzilla_secret')
-JIRA_API_KEY = _get_secret('jira_secret')
+BZ_API_KEY = get_secret('bugzilla_secret', SECRETS_DIR)
+JIRA_API_KEY = get_secret('jira_secret', SECRETS_DIR)
 
 # Secret key ((will be overridden by the content of SECRET_KEY_FILE if available)
-SECRET_KEY = _get_secret('secret_key', directory=SECRET_KEY_DIR) or 'x' * 50
+SECRET_KEY = get_secret('secret_key', SECRET_KEY_DIR) or 'x' * 50

--- a/osh/hub/settings_local.py
+++ b/osh/hub/settings_local.py
@@ -25,6 +25,7 @@ DATABASES = {
         'ENGINE': 'django.db.backends.postgresql',
         'NAME': 'openscanhub',
         'USER': 'openscanhub',
+        # Use osh.hub.other.settings_util.get_secret to load the secret from file.
         'PASSWORD': 'velryba',
         'HOST': 'db',
         'PORT': '5432',


### PR DESCRIPTION
hub: enable reading of secrets in `settings_local.py`

Resolves: https://issues.redhat.com/browse/OSH-387