### PR TITLE
worker: do not use `cspodman --force-global-cleanup-on-exit`

### DIFF
--- a/osh/worker/csmock_runner.py
+++ b/osh/worker/csmock_runner.py
@@ -115,8 +115,6 @@ class CsmockRunner:
 
         if profile == "cspodman":
             cmd = "cspodman"
-            # XXX: this destroys all containers we have access to, related or not
-            cmd += " --force-global-cleanup-on-exit"
         else:
             cmd = "csmock"
             if profile_url:


### PR DESCRIPTION
It was a potentially harmful interim solution, which is no longer needed.
The option is now ignored by cspodman anyway:
```
% cspodman --force-global-cleanup-on-exit ... 
cspodman: warning: --force-global-cleanup-on-exit is not implemented
[...]
``` 

Related: https://issues.redhat.com/browse/OSH-473