### PR TITLE
client: change default hub url to Fedora deployment

### DIFF
--- a/osh.spec
+++ b/osh.spec
@@ -284,6 +284,9 @@ pg_isready -h localhost && %{python3_sitelib}/osh/hub/manage.py migrate
 
 
 %changelog
+* Mon Apr 15 2024 Siteshwar Vashisht <svashisht@redhat.com> - 1.0.0-1
+- use Fedora production deployment as the default hub URL
+
 * Tue Feb 13 2024 Kamil Dudka <kdudka@redhat.com> - 0.9.7-1
 - stabilize a new version of osh-client
 

--- a/osh/client/client.conf
+++ b/osh/client/client.conf
@@ -2,10 +2,10 @@
 
 # Hub XML-RPC address.
 #HUB_URL = "http://localhost:8000/xmlrpc"
-HUB_URL = "https://cov01.lab.eng.brq2.redhat.com/osh/xmlrpc"
+HUB_URL = "https://openscanhub.fedoraproject.org/xmlrpc"
 
 # Comma-separated list of Koji profiles
-KOJI_PROFILES = "brew,koji"
+KOJI_PROFILES = "koji"
 
 DEFAULT_MOCKCONFIG = "fedora-rawhide-x86_64"
 

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ find_namespace_packages = PEP420PackageFinder.find
 
 THIS_FILE_PATH = os.path.dirname(os.path.abspath(__file__))
 
-package_version = "0.9.7"
+package_version = "1.0.0"
 
 data_files = {
     "/etc/osh": [


### PR DESCRIPTION
Related: https://github.com/openscanhub/openscanhub/issues/195