### PR TITLE
hub: fix a copy-paste error in the default e-mail domain

### DIFF
--- a/osh/hub/settings.py
+++ b/osh/hub/settings.py
@@ -183,7 +183,7 @@ VALID_TASK_LOG_EXTENSIONS = ['.log', '.ini', '.err', '.out', '.js', '.txt']
 
 # This is kept here for backward compatibility.
 # https://github.com/openscanhub/openscanhub/pull/256#pullrequestreview-2001187953
-DEFAULT_EMAIL_DOMAIN = "@redhat.com"
+DEFAULT_EMAIL_DOMAIN = "redhat.com"
 
 # override default values with custom ones from local settings
 try:


### PR DESCRIPTION
`DEFAULT_EMAIL_DOMAIN` should not contain the leading `@` because the concatenated string then contains `user@@redhat.com`, which results in difficult-to-debug failures to send e-mail notifications:
```
Apr 22 00:02:52 cov01.lab.eng.brq2.redhat.com postfix/smtpd[2713480]: connect from localhost[::1]
Apr 22 00:02:53 cov01.lab.eng.brq2.redhat.com postfix/smtpd[2713480]: lost connection after CONNECT from localhost[::1]
Apr 22 00:02:53 cov01.lab.eng.brq2.redhat.com postfix/smtpd[2713480]: disconnect from localhost[::1] commands=0/0
Apr 22 00:05:08 cov01.lab.eng.brq2.redhat.com postfix/smtpd[2714548]: connect from localhost[::1]
Apr 22 00:05:08 cov01.lab.eng.brq2.redhat.com postfix/smtpd[2714548]: lost connection after CONNECT from localhost[::1]
Apr 22 00:05:08 cov01.lab.eng.brq2.redhat.com postfix/smtpd[2714548]: disconnect from localhost[::1] commands=0/0
Apr 22 00:12:55 cov01.lab.eng.brq2.redhat.com postfix/smtpd[2718052]: connect from localhost[::1]
Apr 22 00:13:09 cov01.lab.eng.brq2.redhat.com postfix/smtpd[2718052]: lost connection after CONNECT from localhost[::1]
Apr 22 00:13:09 cov01.lab.eng.brq2.redhat.com postfix/smtpd[2718052]: disconnect from localhost[::1] commands=0/0
```

Fixes: commit 52965d4577cf88be9d1d42facd6a729659c8ef26