### PR TITLE
hub: use `module_hotfixes=True` for RHEL-8 and RHEL-9

### DIFF
--- a/osh/hub/scan/mock.py
+++ b/osh/hub/scan/mock.py
@@ -190,6 +190,10 @@ def _create_mock_config(tag, arch, koji_profile, dest_dir):
     # use $basearch for the "[build]" repo
     contents = re.sub(fr'({tag}/latest/){arch}', r'\1$basearch', contents)
 
+    # use module_hotfixes=True for RHEL-8 and RHEL-9
+    if re.search(r'rhel-?[89]', tag):
+        contents = contents.replace("[build]", '[build]\\nmodule_hotfixes=True')
+
     # use randomly generated root directory name
     contents = re.sub(r"(config_opts\['root'\] = '[^']*)'",
                       fr"\1-{uuid.uuid4()}'", contents)


### PR DESCRIPTION
... to avoid the following failure while scanning `less-530-1.el8` with `--config=auto`:
```
Dependencies resolved.
================================================================================
 Package    Arch   Version                              Repository         Size
================================================================================
Installing:
 ShellCheck x86_64 0.8.0-3.el8                          osh-shellcheck-epel
                                                                          3.1 M
 clang      x86_64 7.0.1-1.module+el8.0.0+3181+ec021930 build             722 k
 xml-common noarch 0.6.3-50.el8                         build              38 k
Installing dependencies:
 clang-libs x86_64 7.0.1-1.module+el8.0.0+3181+ec021930 build              16 M
 libatomic  x86_64 8.2.1-3.5.el8                        build              19 k
 llvm-libs  x86_64 7.0.1-3.module+el8.0.0+3181+ec021930 build              17 M

Transaction Summary
================================================================================
Install  6 Packages

Total download size: 37 M
Installed size: 216 M
Downloading Packages:
--------------------------------------------------------------------------------
Total                                            10 MB/s |  37 MB     00:03
Running transaction check
No available modular metadata for modular package 'clang-7.0.1-1.module+el8.0.0+3181+ec021930.x86_64', it cannot be installed on the system
No available modular metadata for modular package 'clang-libs-7.0.1-1.module+el8.0.0+3181+ec021930.x86_64', it cannot be installed on the system
No available modular metadata for modular package 'llvm-libs-7.0.1-3.module+el8.0.0+3181+ec021930.x86_64', it cannot be installed on the system
Error: No available modular metadata for modular package
```