### PR TITLE
allow user to specify task metadata from client

### DIFF
--- a/osh/client/commands/cmd_build.py
+++ b/osh/client/commands/cmd_build.py
@@ -17,7 +17,8 @@ from osh.client.commands.common import (add_analyzers_option,
                                         add_json_option, add_nowait_option,
                                         add_nvr_option, add_priority_option,
                                         add_profile_option,
-                                        add_task_id_file_option)
+                                        add_task_id_file_option,
+                                        add_task_metadata_option)
 from osh.client.commands.shortcuts import (check_analyzers, fetch_results,
                                            handle_perm_denied, upload_file,
                                            verify_koji_build, verify_mock,
@@ -49,6 +50,7 @@ class Base_Build(OshCommand):
         add_priority_option(self.parser)
         add_profile_option(self.parser)
         add_task_id_file_option(self.parser)
+        add_task_metadata_option(self.parser)
 
     def check_build(self, args, kwargs, prefix=""):
         local_conf = get_conf(self.conf)
@@ -104,6 +106,7 @@ is not even one in your user configuration file \
         cov_custom_model = kwargs.get('cov_custom_model')
         csmock_args = kwargs.get('csmock_args')
         email_to = kwargs.get("email_to", [])
+        metadata = kwargs.get("metadata")
         packages_to_install = kwargs.get('install_to_chroot')
         priority = kwargs.get("priority")
         profile = kwargs.get('profile')
@@ -151,6 +154,9 @@ is not even one in your user configuration file \
 
         if packages_to_install:
             options['install_to_chroot'] = packages_to_install
+
+        if metadata:
+            options['metadata'] = metadata
 
         return options
 

--- a/osh/client/commands/common.py
+++ b/osh/client/commands/common.py
@@ -1,6 +1,10 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 # SPDX-FileCopyrightText: Copyright contributors to the OpenScanHub project.
 
+import json
+from optparse import OptionValueError
+
+
 def add_download_results_option(parser):
     parser.add_option(
         "-d",
@@ -149,4 +153,24 @@ def add_tarball_option(parser):
              "then the tarball will be scanned. "
              "This option sets command which should build the package, usually this should be just "
              "\"make\", in case of packages which doesn't need to be built, just pass \"true\".",
+    )
+
+
+def parse_json_option(option, opt, value, parser):
+    try:
+        json_value = json.loads(value)
+    except json.JSONDecodeError:
+        raise OptionValueError(f"Option {opt}: invalid JSON value: {value}")
+
+    setattr(parser.values, option.dest, json_value)
+
+
+def add_task_metadata_option(parser):
+    parser.add_option(
+        "--metadata",
+        dest="metadata",
+        action="callback",
+        callback=parse_json_option,
+        help="Specify task metadata as a JSON string, e.g., "
+             "--metadata='{\"product\": \"RHEL\", \"version\": \"9.3\"}'"
     )

--- a/osh/client/completion/_osh-cli
+++ b/osh/client/completion/_osh-cli
@@ -125,6 +125,7 @@ _osh-cli_args()
                 '--config=[specify mock config name]:osh:->configs'
                 '--comment=[a task description]'
                 '--json[print created task info in JSON]'
+                '--metadata=[specify task metadata as a JSON string]'
                 '--task-id-file=[task id is written to this file]:filename:_files'
                 "--nowait[don't wait until tasks finish]"
                 # '*' enables repetition

--- a/osh/client/completion/osh-cli.bash
+++ b/osh/client/completion/osh-cli.bash
@@ -152,7 +152,7 @@ _osh_cli()
             _osh_cli_complete profiles
             return
             ;;
-        --csmock-args|--comment|--email-to|--priority)
+        --csmock-args|--comment|--metadata|--email-to|--priority)
             COMPREPLY=()
             return
             ;;
@@ -169,7 +169,7 @@ _osh_cli()
             COMPREPLY+=( $(compgen -W "--cov-custom-model=" -- "${cur}") )
             COMPREPLY+=( $(compgen -W "--config=" -- "${cur}") )
             COMPREPLY+=( $(compgen -W "--comment= --task-id-file=" -- "${cur}") )
-            COMPREPLY+=( $(compgen -W "--nowait --email-to=" -- "${cur}") )
+            COMPREPLY+=( $(compgen -W "--metadata= --nowait --email-to=" -- "${cur}") )
             COMPREPLY+=( $(compgen -W "--priority= --json" -- "${cur}") )
             COMPREPLY+=( $(compgen -W "--nvr=" -- "${cur}") )
             ;;

--- a/osh/hub/scan/check.py
+++ b/osh/hub/scan/check.py
@@ -5,6 +5,7 @@
 Functions related to checking provided data
 """
 
+import json
 import logging
 import os
 
@@ -121,3 +122,15 @@ def check_srpm(upload_id, build_nvr, task_user, is_tarball=False):
         }
 
     raise RuntimeError('No source RPM or tarball specified.')
+
+
+def check_task_metadata(metadata):
+    if isinstance(metadata, dict):
+        return metadata
+    if isinstance(metadata, str):
+        try:
+            return json.loads(metadata)
+        except json.JSONDecodeError:
+            raise RuntimeError(f"Invalid JSON value: {metadata}")
+
+    raise RuntimeError(f"Invalid JSON value: {metadata}")

--- a/osh/hub/scan/scanner.py
+++ b/osh/hub/scan/scanner.py
@@ -20,7 +20,8 @@ from kobo.hub.models import TASK_STATES, Arch, Task
 from osh.hub.other.exceptions import PackageBlockedException
 from osh.hub.scan.check import (check_analyzers, check_build, check_nvr,
                                 check_obsolete_scan, check_package_is_blocked,
-                                check_srpm, check_upload, is_container_build)
+                                check_srpm, check_task_metadata, check_upload,
+                                is_container_build)
 from osh.hub.scan.mock import generate_mock_configs
 from osh.hub.scan.models import (REQUEST_STATES, SCAN_TYPES, AppSettings,
                                  ClientAnalyzer, ETMapping, MockConfig,
@@ -487,6 +488,8 @@ class ClientScanScheduler(AbstractClientScanScheduler):
         self.client_csmock_args = self.options.get('csmock_args', None)
 
         self.metadata = self.options.get('metadata')
+        if self.metadata:
+            self.metadata = check_task_metadata(self.metadata)
 
         self.email_to = self.options.get("email_to", None)
 

--- a/osh/hub/scan/scanner.py
+++ b/osh/hub/scan/scanner.py
@@ -486,6 +486,8 @@ class ClientScanScheduler(AbstractClientScanScheduler):
 
         self.client_csmock_args = self.options.get('csmock_args', None)
 
+        self.metadata = self.options.get('metadata')
+
         self.email_to = self.options.get("email_to", None)
 
     def prepare_args(self):
@@ -526,6 +528,10 @@ class ClientScanScheduler(AbstractClientScanScheduler):
         self.task_args['args']['csmock_args'] = csmock_args
         self.task_args['args']['custom_model_name'] = self.model_name
         self.task_args['args']['su_user'] = AppSettings.setting_get_su_user()
+
+        if self.metadata:
+            self.task_args['args']['metadata'] = self.metadata
+
         if self.email_to:
             self.task_args['args']['email_to'] = self.email_to
 


### PR DESCRIPTION
Related: https://issues.redhat.com/browse/OSH-567
Closes: https://github.com/openscanhub/openscanhub/pull/285