### PR TITLE
packaging: use `python3dist` to specify django dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ report bugs and feature requests on GitHub using the above URL.
 - `koji`
 - `mod_auth_gssapi`
 - `mod_ssl`
+- `python3dist(django) >= 3.2.0`
 - `python3-bugzilla`
 - `python3-csdiff`
-- `python3-django >= 3.2.0`
 - `python3-jira`
 - `python3-kobo-client`
 - `python3-kobo-django >= 0.35.0`

--- a/containers/hub/Dockerfile
+++ b/containers/hub/Dockerfile
@@ -28,9 +28,9 @@ RUN dnf -y --setopt=tsflags=nodocs install \
     /usr/bin/pg_isready \
     csdiff \
     gzip \
+    'python3dist(django) >= 3.2.0' \
     python3-bugzilla \
     python3-csdiff \
-    python3-django3 \
     python3-gssapi \
     python3-jira \
     python3-psycopg2 \

--- a/osh.spec
+++ b/osh.spec
@@ -10,9 +10,9 @@ Source:         https://github.com/openscanhub/openscanhub/archive/refs/tags/%{n
 BuildArch:      noarch
 
 BuildRequires:  koji
+BuildRequires:  python3dist(django) >= %{min_required_version_django}
 BuildRequires:  python3-csdiff
 BuildRequires:  python3-devel
-BuildRequires:  python3-django >= %{min_required_version_django}
 BuildRequires:  python3-kobo-client
 BuildRequires:  python3-kobo-django
 BuildRequires:  python3-kobo-hub
@@ -83,7 +83,7 @@ Summary: OpenScanHub xml-rpc interface and web application
 Requires: httpd
 Requires: mod_auth_gssapi
 Requires: mod_ssl
-Requires: python3-django >= %{min_required_version_django}
+Requires: python3dist(django) >= %{min_required_version_django}
 Requires: python3-kobo-client
 Requires: python3-kobo-django >= 0.35.0
 Requires: python3-kobo-hub >= 0.35.0

--- a/tests/ci.fmf
+++ b/tests/ci.fmf
@@ -1,3 +1,3 @@
 summary: Test builds on Testing Farm CI
 test: ./ci.sh
-duration: 20m
+duration: 1h


### PR DESCRIPTION
... to make OSH compatible with versioned Django packages in EPEL and Fedora.