### PR TITLE
hub: fix a sentence in the homepage

### DIFF
--- a/osh/hub/templates/index-content.html
+++ b/osh/hub/templates/index-content.html
@@ -5,7 +5,7 @@ OpenScanHub is a service that runs various static analyzers on RPM packages. The
 </p>
 
 <p>
-OpenScanHub by default uses <a href="https://github.com/danmar/cppcheck">Cppcheck</a>, <a
+OpenScanHub by default can use <a href="https://github.com/danmar/cppcheck">Cppcheck</a>, <a
     href="https://www.shellcheck.net/">ShellCheck</a>, the static analyzers embedded in <a
     href="https://developers.redhat.com/blog/2020/03/26/static-analysis-in-gcc-10">GCC</a> and <a
     href="https://clang-analyzer.llvm.org/">Clang</a>, and the <a


### PR DESCRIPTION
Some of these plugins may be disabled, so this sentence is not always accurate.