### PR TITLE
codeowners: remove @lzaoral

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,10 +7,10 @@
 # precedence.
 
 # Default reviewers
-* @kdudka @lzaoral
+* @kdudka
 
 # Reviewers for specific paths
-.github/     @kdudka @lzaoral @siteshwar
-.packit.yaml @kdudka @lzaoral @siteshwar
-containers/  @kdudka @lzaoral @siteshwar
-tests/       @kdudka @lzaoral @siteshwar
+.github/     @kdudka @siteshwar
+.packit.yaml @kdudka @siteshwar
+containers/  @kdudka @siteshwar
+tests/       @kdudka @siteshwar


### PR DESCRIPTION
The RHEL-related responsibilities take the majority of my work-time and I don't have time nor the motivation to be the main reviewer for this project.

From now on, I'd like to officially limit my contributions only to critical regressions which is the actual state of things for few past months anyway.  I'll try to finish #243 soon but other QOL improvements or (much needed) refactoring is out of scope for me.