### PR TITLE
client: explicitly specify expected --metadata type

### DIFF
--- a/osh/client/commands/common.py
+++ b/osh/client/commands/common.py
@@ -169,6 +169,7 @@ def add_task_metadata_option(parser):
     parser.add_option(
         "--metadata",
         dest="metadata",
+        type="string",
         action="callback",
         callback=parse_json_option,
         help="Specify task metadata as a JSON string, e.g., "


### PR DESCRIPTION
otherwise the callback function is unable to correctly handle the value passed to the option, raising errors like this:

osh-cli: error: --metadata option does not take a value

Related: https://issues.redhat.com/browse/OSH-567