### PR TITLE
packaging: use psycopg3 on Fedora 41+

### DIFF
--- a/osh.spec
+++ b/osh.spec
@@ -1,5 +1,11 @@
 %global min_required_version_django 3.2
 
+%if 0%{?fedora} < 41
+%global psycopg_pkg python3-psycopg2
+%else
+%global psycopg_pkg python3-psycopg3
+%endif
+
 Name:           osh
 Version:        %{version}
 Release:        2%{?dist}
@@ -17,7 +23,7 @@ BuildRequires:  python3-kobo-client
 BuildRequires:  python3-kobo-django
 BuildRequires:  python3-kobo-hub
 BuildRequires:  python3-kobo-rpmlib
-BuildRequires:  python3-psycopg2
+BuildRequires:  %{psycopg_pkg}
 BuildRequires:  python3-qpid-proton
 BuildRequires:  python3-setuptools
 BuildRequires:  python3-setuptools_scm
@@ -90,7 +96,7 @@ Requires: python3-kobo-hub >= 0.35.0
 Requires: python3-kobo-rpmlib
 Requires: python3-mod_wsgi
 # PostgreSQL adapter for python
-Requires: python3-psycopg2
+Requires: %{psycopg_pkg}
 Requires: gzip
 # inform ET about progress using UMB (Unified Message Bus)
 Requires: python3-qpid-proton

--- a/osh/hub/osh-hub-httpd.conf.in
+++ b/osh/hub/osh-hub-httpd.conf.in
@@ -18,6 +18,7 @@ WSGISocketPrefix /var/run/wsgi
     SSLCertificateKeyFile   /etc/httpd/conf/localhost.key
 
     # WSGI handler
+    WSGIApplicationGroup %{GLOBAL}
     WSGIDaemonProcess osh display-name=%{GROUP} locale='C.UTF-8'
     WSGIProcessGroup osh
     WSGIScriptAlias /osh @PYTHON3_SITELIB@/osh/hub/osh-hub.wsgi process-group=osh


### PR DESCRIPTION
psycopg2 does not work well on Fedora 41:
```
[Tue Nov 19 12:34:11.390423 2024] [wsgi:error] [pid 5254:tid 5355] [remote ::1:34968] mod_wsgi (pid=5254): Failed to exec Python script file '/usr/lib/python3.13/site-packages/osh/hub/osh-hub.wsgi'.
[Tue Nov 19 12:34:11.390462 2024] [wsgi:error] [pid 5254:tid 5355] [remote ::1:34968] mod_wsgi (pid=5254): Exception occurred processing WSGI script '/usr/lib/python3.13/site-packages/osh/hub/osh-hub.wsgi'.
[Tue Nov 19 12:34:11.397438 2024] [wsgi:error] [pid 5254:tid 5355] [remote ::1:34968] Traceback (most recent call last):
[Tue Nov 19 12:34:11.397635 2024] [wsgi:error] [pid 5254:tid 5355] [remote ::1:34968]   File "/usr/lib/python3.13/site-packages/django/db/backends/postgresql/base.py", line 25, in <module>
[Tue Nov 19 12:34:11.397643 2024] [wsgi:error] [pid 5254:tid 5355] [remote ::1:34968]     import psycopg as Database
[Tue Nov 19 12:34:11.397655 2024] [wsgi:error] [pid 5254:tid 5355] [remote ::1:34968] ModuleNotFoundError: No module named 'psycopg'
[Tue Nov 19 12:34:11.397698 2024] [wsgi:error] [pid 5254:tid 5355] [remote ::1:34968]
[Tue Nov 19 12:34:11.397702 2024] [wsgi:error] [pid 5254:tid 5355] [remote ::1:34968] During handling of the above exception, another exception occurred:
[Tue Nov 19 12:34:11.397706 2024] [wsgi:error] [pid 5254:tid 5355] [remote ::1:34968]
[Tue Nov 19 12:34:11.397712 2024] [wsgi:error] [pid 5254:tid 5355] [remote ::1:34968] Traceback (most recent call last):
[Tue Nov 19 12:34:11.397855 2024] [wsgi:error] [pid 5254:tid 5355] [remote ::1:34968]   File "/usr/lib/python3.13/site-packages/django/db/backends/postgresql/base.py", line 27, in <module>
[Tue Nov 19 12:34:11.397861 2024] [wsgi:error] [pid 5254:tid 5355] [remote ::1:34968]     import psycopg2 as Database
[Tue Nov 19 12:34:11.397867 2024] [wsgi:error] [pid 5254:tid 5355] [remote ::1:34968]   File "/usr/lib64/python3.13/site-packages/psycopg2/__init__.py", line 67, in <module>
[Tue Nov 19 12:34:11.397871 2024] [wsgi:error] [pid 5254:tid 5355] [remote ::1:34968]     from psycopg2 import extensions as _ext
[Tue Nov 19 12:34:11.397876 2024] [wsgi:error] [pid 5254:tid 5355] [remote ::1:34968]   File "/usr/lib64/python3.13/site-packages/psycopg2/extensions.py", line 50, in <module>
[Tue Nov 19 12:34:11.397881 2024] [wsgi:error] [pid 5254:tid 5355] [remote ::1:34968]     from psycopg2._psycopg import (                             # noqa
[Tue Nov 19 12:34:11.397884 2024] [wsgi:error] [pid 5254:tid 5355] [remote ::1:34968]     ...<5 lines>...
[Tue Nov 19 12:34:11.397888 2024] [wsgi:error] [pid 5254:tid 5355] [remote ::1:34968]         set_wait_callback, get_wait_callback, encrypt_password, )
[Tue Nov 19 12:34:11.397897 2024] [wsgi:error] [pid 5254:tid 5355] [remote ::1:34968] ImportError: cannot import name 'encodings' from 'psycopg2._psycopg' (/usr/lib64/python3.13/site-packages/psycopg2/_psycopg.cpython-313-x86_64-linux-gnu.so)
```