### PR TITLE
containers/scripts: fix issues reported by ShellCheck

### DIFF
--- a/containers/scripts/generate_integration_test_coverage.sh
+++ b/containers/scripts/generate_integration_test_coverage.sh
@@ -97,10 +97,10 @@ main() {
 
     podman exec osh-client "${CLI_XML[@]}" --hub http://osh-hub:8000/xmlrpc/kerbauth/ --username=user --password=xxxxxx create-scan -b $LIBSSH2_NVR -t $LIBSSH2_NVR --et-scan-id=1 --release=Fedora-$FEDORA_VERSION --owner=admin --advisory-id=1
 
-    SCAN_STATUS=`podman exec osh-client "${CLI_XML[@]}" --hub http://osh-hub:8000/xmlrpc/kerbauth/ --username=user --password=xxxxxx get-scan-state 1 2>&1`
+    SCAN_STATUS="$(podman exec osh-client "${CLI_XML[@]}" --hub http://osh-hub:8000/xmlrpc/kerbauth/ --username=user --password=xxxxxx get-scan-state 1 2>&1)"
     while [[ $SCAN_STATUS == *"QUEUED"* ]] || [[ $SCAN_STATUS == *"SCANNING"* ]]; do
         sleep 10
-        SCAN_STATUS=`podman exec osh-client "${CLI_XML[@]}" --hub http://osh-hub:8000/xmlrpc/kerbauth/ --username=user --password=xxxxxx get-scan-state 1 2>&1`
+        SCAN_STATUS="$(podman exec osh-client "${CLI_XML[@]}" --hub http://osh-hub:8000/xmlrpc/kerbauth/ --username=user --password=xxxxxx get-scan-state 1 2>&1)"
     done
 
     [[ $SCAN_STATUS == *"PASSED"* ]]
@@ -116,10 +116,10 @@ main() {
     # submit errata scan and check its tasks priorities
     podman exec osh-client "${CLI_XML[@]}" --hub http://osh-hub:8000/xmlrpc/kerbauth/ --username=user --password=xxxxxx create-scan -b $EXPAT_NVR -t $EXPAT_NVR --et-scan-id=1 --release=Fedora-$FEDORA_VERSION --owner=admin --advisory-id=1
 
-    SCAN_STATUS=`podman exec osh-client "${CLI_XML[@]}" --hub http://osh-hub:8000/xmlrpc/kerbauth/ --username=user --password=xxxxxx get-scan-state 2 2>&1`
+    SCAN_STATUS="$(podman exec osh-client "${CLI_XML[@]}" --hub http://osh-hub:8000/xmlrpc/kerbauth/ --username=user --password=xxxxxx get-scan-state 2 2>&1)"
     while [[ $SCAN_STATUS == *"QUEUED"* ]] || [[ $SCAN_STATUS == *"SCANNING"* ]]; do
         sleep 10
-        SCAN_STATUS=`podman exec osh-client "${CLI_XML[@]}" --hub http://osh-hub:8000/xmlrpc/kerbauth/ --username=user --password=xxxxxx get-scan-state 2 2>&1`
+        SCAN_STATUS="$(podman exec osh-client "${CLI_XML[@]}" --hub http://osh-hub:8000/xmlrpc/kerbauth/ --username=user --password=xxxxxx get-scan-state 2 2>&1)"
     done
 
     [[ $SCAN_STATUS == *"PASSED"* ]]
@@ -128,7 +128,7 @@ main() {
     podman exec osh-client "${CLI_COV[@]}" task-info 8 | grep "priority = 11"
 
     # verify subtask priority inheritance if we have recent enough Kobo
-    if [ $(git -C kobo log --tags --oneline --grep='0\.26\.0' | wc -l) == 1 ]; then
+    if [ "$(git -C kobo log --tags --oneline --grep='0\.26\.0' | wc -l)" == 1 ]; then
         podman exec osh-client "${CLI_COV[@]}" task-info 9 | grep "priority = 11"
     fi
 

--- a/containers/scripts/generate_integration_test_coverage.sh
+++ b/containers/scripts/generate_integration_test_coverage.sh
@@ -99,9 +99,9 @@ main() {
 
     SCAN_STATUS=`podman exec osh-client "${CLI_XML[@]}" --hub http://osh-hub:8000/xmlrpc/kerbauth/ --username=user --password=xxxxxx get-scan-state 1 2>&1`
     while [[ $SCAN_STATUS == *"QUEUED"* ]] || [[ $SCAN_STATUS == *"SCANNING"* ]]; do
-        sleep 10;
+        sleep 10
         SCAN_STATUS=`podman exec osh-client "${CLI_XML[@]}" --hub http://osh-hub:8000/xmlrpc/kerbauth/ --username=user --password=xxxxxx get-scan-state 1 2>&1`
-    done;
+    done
 
     [[ $SCAN_STATUS == *"PASSED"* ]]
 
@@ -118,9 +118,9 @@ main() {
 
     SCAN_STATUS=`podman exec osh-client "${CLI_XML[@]}" --hub http://osh-hub:8000/xmlrpc/kerbauth/ --username=user --password=xxxxxx get-scan-state 2 2>&1`
     while [[ $SCAN_STATUS == *"QUEUED"* ]] || [[ $SCAN_STATUS == *"SCANNING"* ]]; do
-        sleep 10;
+        sleep 10
         SCAN_STATUS=`podman exec osh-client "${CLI_XML[@]}" --hub http://osh-hub:8000/xmlrpc/kerbauth/ --username=user --password=xxxxxx get-scan-state 2 2>&1`
-    done;
+    done
 
     [[ $SCAN_STATUS == *"PASSED"* ]]
 
@@ -163,8 +163,7 @@ main() {
     podman cp osh-client:/cov/coverage .
 
     # Avoid generating html reports in GitHub Actions CI
-    if [[ "$GITHUB_ACTIONS" = "true" ]];
-    then
+    if [[ "$GITHUB_ACTIONS" = "true" ]]; then
         # We use codecov in GitHub Actions CI. Upload xml reports to it.
         podman exec -it osh-client /usr/bin/coverage-3 xml --rcfile=/coveragerc -o /cov/coverage.xml
         podman cp osh-client:/cov/coverage.xml .


### PR DESCRIPTION
```
Error: SHELLCHECK_WARNING:
containers/scripts/generate_integration_test_coverage.sh:100:17: style[SC2006]: Use $(...) notation instead of legacy backticks `...`.

Error: SHELLCHECK_WARNING:
containers/scripts/generate_integration_test_coverage.sh:103:21: style[SC2006]: Use $(...) notation instead of legacy backticks `...`.

Error: SHELLCHECK_WARNING:
containers/scripts/generate_integration_test_coverage.sh:119:17: style[SC2006]: Use $(...) notation instead of legacy backticks `...`.

Error: SHELLCHECK_WARNING:
containers/scripts/generate_integration_test_coverage.sh:122:21: style[SC2006]: Use $(...) notation instead of legacy backticks `...`.

Error: SHELLCHECK_WARNING:
containers/scripts/generate_integration_test_coverage.sh:131:10: warning[SC2046]: Quote this to prevent word splitting.
```
Related: https://github.com/openscanhub/openscanhub/issues/151