### PR TITLE
Remove "We are checking" from scan failed message

### DIFF
--- a/osh/hub/waiving/views.py
+++ b/osh/hub/waiving/views.py
@@ -124,8 +124,7 @@ def get_result_context(request, sb):
         context['fixed_count'] = f_count
         context['old_count'] = o_count
     elif sb.scan.state == SCAN_STATES['FAILED']:
-        context['not_finished'] = "Scan wasn't successful. \
-We are checking what happened."
+        context['not_finished'] = "Scan wasn't successful."
     elif sb.scan.state == SCAN_STATES['CANCELED']:
         context['not_finished'] = "Scan is canceled (is superseded by newer \
 one)."


### PR DESCRIPTION
This message was somewhat misleading, as it wasn't guaranteed that anyone was actually investigating the failed scan.