### PR TITLE
hub: improve error msg when generating mock config

### DIFF
--- a/osh/hub/scan/mock.py
+++ b/osh/hub/scan/mock.py
@@ -227,6 +227,7 @@ def generate_mock_configs(nvr, koji_profile):
     method = task['method']
     params = koji.parse_task_params(method, task['request'])
 
+    tag = None
     # parse build tag name from task parameters
     if method == 'build':
         # obtain module build target
@@ -239,7 +240,8 @@ def generate_mock_configs(nvr, koji_profile):
     elif method == 'wrapperRPM':
         tag = params['build_target']['build_tag_name']
     # TODO: add other methods
-    else:
+
+    if tag is None:
         raise RuntimeError(f'No build target for "{nvr}" available!')
 
     # assert that the selected tag always exists


### PR DESCRIPTION
When requesting a scan with --config=auto, a valid build target for the koji NVR is needed. If this was undefined it was possible koji.getTag() to be called with a null parameter, causing a stack trace. Instead let's raise a RuntimeError before calling getTag().