### PR TITLE
hub: use Python tarfile module instead of tar subprocess

### DIFF
--- a/.github/workflows/django-unit-tests.yml
+++ b/.github/workflows/django-unit-tests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        centos-stream: [8, 9]
+        centos-stream: [9]
 
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        centos-stream: [8, 9]
+        centos-stream: [9]
 
     runs-on: ubuntu-24.04
     steps:

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -33,7 +33,6 @@ jobs:
       trigger: pull_request
       targets:
           - fedora-all-x86_64
-          - epel-8-x86_64
           - epel-9-x86_64
 
     - <<: *copr
@@ -47,7 +46,6 @@ jobs:
       trigger: pull_request
       targets:
           - fedora-latest-stable-x86_64
-          - epel-8-x86_64
           - epel-9-x86_64
 
     - <<: *testing_farm

--- a/osh/hub/service/csmock_parser.py
+++ b/osh/hub/service/csmock_parser.py
@@ -1,11 +1,12 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 # SPDX-FileCopyrightText: Copyright contributors to the OpenScanHub project.
 
+import fnmatch
 import glob
 import json
 import logging
 import os
-import subprocess
+import tarfile
 import tempfile
 
 RESULT_FILE_JSON = 'scan-results.js'
@@ -39,23 +40,24 @@ class ResultsExtractor:
         return self._json_path
 
     def extract_tarball(self, exclude_patterns=None):
-        """
-
-        """
         exclude_patterns = exclude_patterns or []
-        exclude_patterns.append("*debug")  # do not unpack debug dir
-        # python 2 does not support lzma
-        command = [
-            'tar', '-xf', self.path,
-            '-C', self.output_dir,
-            '--wildcards',
-            '--wildcards-match-slash',
-        ]
-        if exclude_patterns:
-            # do NOT quote pattern! it won't work
-            command += ['--exclude=' + p for p in exclude_patterns]
-        logger.debug('Running command %s', command)
-        subprocess.check_call(command)
+        exclude_patterns.append("*debug")
+        logger.debug('Extracting %s to %s (excluding %s)',
+                     self.path, self.output_dir, exclude_patterns)
+        # filter='data' strips ownership/permissions (Python 3.12+)
+        extract_kwargs = {}
+        if hasattr(tarfile, 'data_filter'):
+            extract_kwargs['filter'] = 'data'
+        with tarfile.open(self.path) as tf:
+            for member in tf.getmembers():
+                # match each path component against exclude patterns
+                # to replicate tar's --wildcards-match-slash --exclude
+                parts = member.name.rstrip('/').split('/')
+                if any(fnmatch.fnmatch(part, p)
+                       for part in parts
+                       for p in exclude_patterns):
+                    continue
+                tf.extract(member, path=self.output_dir, **extract_kwargs)
 
     def get_json_result_path(self):
         return self.json_path

--- a/tests/ci.sh
+++ b/tests/ci.sh
@@ -52,7 +52,19 @@ UNITS_NVR="units-2.24-4.fc$FEDORA_VERSION"
 
 # Test OpenScanHub
 /usr/bin/osh-cli mock-build --config=auto --nvr $UNITS_NVR
-/usr/bin/osh-cli task-info 1 | grep "is_failed = False"
+/usr/bin/osh-cli task-info 1 | grep "is_failed = False" || {
+    osh-cli download-results 1
+    tar -xf "${UNITS_NVR}.tar.xz" "${UNITS_NVR}/scan.log" --to-command=cat
+    tail -n1024 /var/log/{httpd/error_log,osh/{hub/hub,worker}.log}
+    cd /var/lib/osh/hub/tasks/0/0/1/
+    for log in {error,traceback}.log.gz; do
+        if test -r "$log"; then
+            gzip -cd "$log"
+        fi
+    done
+    exit 1
+}
+ls -Ral /var/lib/osh/hub/tasks/0/0/1/
 
 (cd /tmp && koji download-build -a src $UNITS_NVR)
 /usr/bin/osh-cli diff-build --config=fedora-$FEDORA_VERSION-x86_64 /tmp/$UNITS_NVR.src.rpm


### PR DESCRIPTION
## Summary
- Replace `subprocess.check_call(['tar', ...])` with Python's `tarfile` module for extracting result tarballs
- `tar` 1.35-8 started using the `openat2()` syscall, which gets blocked by httpd's systemd hardening (seccomp filters), causing `ENOSYS` ("Function not implemented")
- Python's `tarfile` module uses standard `open()`/`openat()` and is not affected by the seccomp restrictions
- Drop el8-based CI jobs — the `python3-django3` package they depend on was removed from `epel-8`

## Test plan
- [ ] Verify the `testing-farm:fedora-*` CI jobs pass
- [ ] Verify tarball extraction still correctly excludes `*debug` and `*cov` directories

Related: https://bugzilla.redhat.com/show_bug.cgi?id=2437037
Related: https://lists.pagure.io/archives/list/epel-devel@lists.fedoraproject.org/thread/O5CZAH6EYPDFCGRSZIXB32QTPTNEQRQW/

🤖 Generated with [Claude Code](https://claude.com/claude-code)