### PR TITLE
ci: drop epel-8 build targets

### DIFF
--- a/.github/workflows/django-unit-tests.yml
+++ b/.github/workflows/django-unit-tests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        centos-stream: [8, 9]
+        centos-stream: [9]
 
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        centos-stream: [8, 9]
+        centos-stream: [9]
 
     runs-on: ubuntu-24.04
     steps:

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -33,7 +33,6 @@ jobs:
       trigger: pull_request
       targets:
           - fedora-all-x86_64
-          - epel-8-x86_64
           - epel-9-x86_64
 
     - <<: *copr
@@ -47,7 +46,6 @@ jobs:
       trigger: pull_request
       targets:
           - fedora-latest-stable-x86_64
-          - epel-8-x86_64
           - epel-9-x86_64
 
     - <<: *testing_farm


### PR DESCRIPTION
python-django has been removed from EPEL-8, breaking the build.

See: https://lists.pagure.io/archives/list/epel-devel@lists.fedoraproject.org/thread/O5CZAH6EYPDFCGRSZIXB32QTPTNEQRQW/