### PR TITLE
fix(hub): handle scan elapsed time over 24 hours

### DIFF
--- a/osh/hub/service/csmock_parser.py
+++ b/osh/hub/service/csmock_parser.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 # SPDX-FileCopyrightText: Copyright contributors to the OpenScanHub project.
 
+import datetime
 import fnmatch
 import glob
 import json
@@ -148,6 +149,13 @@ class CsmockAPI:
                 analyzer = {'name': key[17:], 'version': value}
                 analyzers.append(analyzer)
         return analyzers
+
+
+def parse_elapsed_time(time_str):
+    """Parse an HH:MM:SS time string into total seconds, allowing hours > 23."""
+    hours, minutes, seconds = time_str.split(':')
+    td = datetime.timedelta(hours=int(hours), minutes=int(minutes), seconds=int(seconds))
+    return int(td.total_seconds())
 
 
 def unpack_and_return_api(tb_path, in_dir=""):

--- a/osh/hub/waiving/results_loader.py
+++ b/osh/hub/waiving/results_loader.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 # SPDX-FileCopyrightText: Copyright contributors to the OpenScanHub project.
 
-import datetime
 import logging
 
 from django.core.exceptions import ObjectDoesNotExist
@@ -9,7 +8,8 @@ from kobo.hub.models import Task
 
 from osh.common.constants import DEFAULT_CHECKER_GROUP
 from osh.hub.scan.models import AnalyzerVersion, AppSettings
-from osh.hub.service.csmock_parser import CsmockAPI, ResultsExtractor
+from osh.hub.service.csmock_parser import (CsmockAPI, ResultsExtractor,
+                                           parse_elapsed_time)
 from osh.hub.service.path import TaskResultPaths
 from osh.hub.service.processing import (TaskDiffer, task_has_results,
                                         task_is_diffed)
@@ -130,11 +130,7 @@ class ResultsLoader:
         self.result.lines = scan_metadata.get('cov-lines-processed', None)
         time = scan_metadata.get('cov-time-elapsed-analysis', None)
         if time:
-            t = datetime.datetime.strptime(time, "%H:%M:%S")
-            time_delta = datetime.timedelta(hours=t.hour,
-                                            minutes=t.minute,
-                                            seconds=t.second)
-            self.result.scanning_time = int(time_delta.days * 86400 + time_delta.seconds)
+            self.result.scanning_time = parse_elapsed_time(time)
         self.result.save()
 
         self.sb.result = self.result

--- a/osh/tests/hub/service/test_csmock_parser.py
+++ b/osh/tests/hub/service/test_csmock_parser.py
@@ -1,0 +1,23 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-FileCopyrightText: Copyright contributors to the OpenScanHub project.
+
+import unittest
+
+from osh.hub.service.csmock_parser import parse_elapsed_time
+
+
+class TestParseElapsedTime(unittest.TestCase):
+    def test_normal_time(self):
+        self.assertEqual(parse_elapsed_time("01:30:00"), 5400)
+
+    def test_zero(self):
+        self.assertEqual(parse_elapsed_time("00:00:00"), 0)
+
+    def test_over_24_hours(self):
+        self.assertEqual(parse_elapsed_time("30:45:44"), 110744)
+
+    def test_exactly_24_hours(self):
+        self.assertEqual(parse_elapsed_time("24:00:00"), 86400)
+
+    def test_large_hours(self):
+        self.assertEqual(parse_elapsed_time("100:00:00"), 360000)


### PR DESCRIPTION
Extract parse_elapsed_time() into csmock_parser and use timedelta directly instead of strptime("%H:%M:%S"), which rejects hours > 23 and crashes result processing for long-running scans.

https://redhat.atlassian.net/browse/PSSECAUT-1603